### PR TITLE
Unuse C#8.0 syntax sugar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Monkey testing helper library for Unity Test Framework
+# Monkey testing library for Unity Test Framework
 
 [![Meta file check](https://github.com/nowsprinting/test-helper.monkey/actions/workflows/metacheck.yml/badge.svg)](https://github.com/nowsprinting/test-helper.monkey/actions/workflows/metacheck.yml)
 
@@ -35,6 +35,12 @@ public void FindAndOperationInteractiveComponent()
 ```
 
 
+## Limitations
+
+In batchmode, `InteractiveComponent.IsReallyInteractiveFromUser` for UI elements is always false.
+Because `UnityEngine.UI.GraphicRaycaster` does not work in batchmode.
+
+
 ## Installation
 
 If you installed [openupm-cli](https://github.com/openupm/openupm-cli), run the command below
@@ -48,12 +54,6 @@ Or open Package Manager window (Window | Package Manager) and add package from g
 ```
 https://github.com/nowsprinting/test-helper.monkey.git
 ```
-
-
-## Limitations
-
-In batchmode, `InteractiveComponent.IsReallyInteractiveFromUser` for UI elements is always false.
-Because `UnityEngine.UI.GraphicRaycaster` does not work in batchmode.
 
 
 ## License

--- a/Runtime/InteractiveComponent.cs
+++ b/Runtime/InteractiveComponent.cs
@@ -58,10 +58,10 @@ namespace TestHelper.Monkey
                 return false;
             }
 
-            eventData ??= new PointerEventData(EventSystem.current);
+            eventData = eventData ?? new PointerEventData(EventSystem.current);
             eventData.position = gameObject.GetScreenPoint();
 
-            results ??= new List<RaycastResult>();
+            results = results ?? new List<RaycastResult>();
             results.Clear();
 
             EventSystem.current.RaycastAll(eventData, results);

--- a/Runtime/Operators/ClickOperator.cs
+++ b/Runtime/Operators/ClickOperator.cs
@@ -28,7 +28,7 @@ namespace TestHelper.Monkey.Operators
 
         internal static void Click(MonoBehaviour component)
         {
-            if (component is not IPointerClickHandler handler)
+            if (!(component is IPointerClickHandler handler))
             {
                 return;
             }

--- a/Runtime/Operators/LongTapOperator.cs
+++ b/Runtime/Operators/LongTapOperator.cs
@@ -31,7 +31,7 @@ namespace TestHelper.Monkey.Operators
 
         internal static async Task LongTap(MonoBehaviour component, int delayMillis = 1000)
         {
-            if (component is not (IPointerDownHandler downHandler and IPointerUpHandler upHandler))
+            if (!(component is IPointerDownHandler downHandler) || !(component is IPointerUpHandler upHandler))
             {
                 return;
             }

--- a/Runtime/Random/IRandom.cs
+++ b/Runtime/Random/IRandom.cs
@@ -5,6 +5,6 @@ namespace TestHelper.Monkey.Random
 {
     public interface IRandom
     {
-        public int Next(int maxValue);
+        int Next(int maxValue);
     }
 }

--- a/Tests/Runtime/MonkeyTest.cs
+++ b/Tests/Runtime/MonkeyTest.cs
@@ -138,10 +138,14 @@ namespace TestHelper.Monkey
         {
             var components = new List<InteractiveComponent>()
             {
-                new(GameObject.Find("UsingOnPointerClickHandler").GetComponent<SpyOnPointerClickHandler>()),
-                new(GameObject.Find("UsingPointerClickEventTrigger").GetComponent<EventTrigger>()),
-                new(GameObject.Find("UsingOnPointerDownUpHandler").GetComponent<SpyOnPointerDownUpHandler>()),
-                new(GameObject.Find("UsingPointerDownUpEventTrigger").GetComponent<EventTrigger>()),
+                new InteractiveComponent(
+                    GameObject.Find("UsingOnPointerClickHandler").GetComponent<SpyOnPointerClickHandler>()),
+                new InteractiveComponent(
+                    GameObject.Find("UsingPointerClickEventTrigger").GetComponent<EventTrigger>()),
+                new InteractiveComponent(
+                    GameObject.Find("UsingOnPointerDownUpHandler").GetComponent<SpyOnPointerDownUpHandler>()),
+                new InteractiveComponent(
+                    GameObject.Find("UsingPointerDownUpEventTrigger").GetComponent<EventTrigger>()),
             };
             components[0].gameObject.SetActive(false);
 
@@ -158,7 +162,8 @@ namespace TestHelper.Monkey
         {
             var components = new List<InteractiveComponent>()
             {
-                new(GameObject.Find("UsingOnPointerClickHandler").GetComponent<SpyOnPointerClickHandler>()),
+                new InteractiveComponent(
+                    GameObject.Find("UsingOnPointerClickHandler").GetComponent<SpyOnPointerClickHandler>()),
             };
             components[0].gameObject.SetActive(false);
 
@@ -174,7 +179,7 @@ namespace TestHelper.Monkey
         {
             var components = new List<InteractiveComponent>()
             {
-                new(GameObject.Find("UsingMultipleEventTriggers").GetComponent<EventTrigger>()),
+                new InteractiveComponent(GameObject.Find("UsingMultipleEventTriggers").GetComponent<EventTrigger>()),
             };
             components[0].gameObject.AddComponent<IgnoreAnnotation>();
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "com.cysharp.unitask": "2.3.3",
     "com.unity.modules.ui": "1.0.0",
-    "com.unity.test-framework": "1.3.2",
     "com.unity.ugui": "1.0.0"
   },
   "displayName": "Monkey Testing Helper",


### PR DESCRIPTION
- Unuse C#8.0 syntax sugar
- Remove test-framework v1.3 from dependencies
- Mod README.md
