### PR TITLE
Remove pin install packages version in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
         unityVersion: # Available versions see: https://game.ci/docs/docker/versions
           - 2019.4.40f1
           - 2022.2.5f1
+          - 2022.2.12f1
         include:
           - unityVersion: 2022.2.5f1
             octocov: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,9 +76,9 @@ jobs:
       - name: Install dependencies
         run: |
           npm install -g openupm-cli
-          openupm add -f com.unity.test-framework@1.3.2
-          openupm add -f com.unity.testtools.codecoverage@1.2.2
-          openupm add -f com.cysharp.unitask@2.3.3
+          openupm add -f com.unity.test-framework
+          openupm add -f com.unity.testtools.codecoverage
+          openupm add -f com.cysharp.unitask
           openupm add -ft "${{ env.package_name }}"@file:../../
         working-directory: ${{ env.CREATED_PROJECT_PATH }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,9 @@ jobs:
       matrix:
         unityVersion: # Available versions see: https://game.ci/docs/docker/versions
           - 2019.4.40f1
-          - 2022.2.5f1
-          - 2022.2.12f1
+          - 2022.2.19f1
         include:
-          - unityVersion: 2022.2.5f1
+          - unityVersion: 2022.2.19f1
             octocov: true
 
     steps:


### PR DESCRIPTION
- Remove pin install packages version in test workflow
- Upgrade Unity to 2022.2.19f1 for test run on CI