### PR TITLE
Cut out RunStep from Run

### DIFF
--- a/Tests/Runtime/MonkeyTest.cs
+++ b/Tests/Runtime/MonkeyTest.cs
@@ -33,6 +33,37 @@ namespace TestHelper.Monkey
         }
 
         [Test]
+        public async Task RunStep_finish()
+        {
+            var config = new MonkeyConfig
+            {
+                DelayMillis = 1, // 1ms
+                TouchAndHoldDelayMillis = 1, // 1ms
+            };
+
+            var didAct = await Monkey.RunStep(config);
+            Assert.That(didAct, Is.EqualTo(true));
+        }
+
+        [Test]
+        public async Task RunStep_noInteractiveComponent_abort()
+        {
+            foreach (var component in InteractiveComponentCollector.FindInteractiveComponents(false))
+            {
+                component.gameObject.SetActive(false);
+            }
+
+            var config = new MonkeyConfig
+            {
+                DelayMillis = 1, // 1ms
+                TouchAndHoldDelayMillis = 1, // 1ms
+            };
+
+            var didAct = await Monkey.RunStep(config);
+            Assert.That(didAct, Is.EqualTo(false));
+        }
+
+        [Test]
         public async Task Run_finish()
         {
             var config = new MonkeyConfig


### PR DESCRIPTION
Hi, I want only a part of `Run` to branch by a condition in `Run()` as following:

```csharp
public static async UniTask Run(MonkeyConfig config, CancellationToken cancellationToken = default)
{
    var endTime = config.Lifetime == TimeSpan.MaxValue
        ? TimeSpan.MaxValue.TotalSeconds
        : config.Lifetime.Add(TimeSpan.FromSeconds(Time.time)).TotalSeconds;

    config.Logger.Log($"Using {config.Random}");
    var lastOperationTime = Time.time;

    while (Time.time < endTime)
    {
        if (SomeConditionSatisifed) // added
        {                           // added
            DoSomething();          // added
        }                           // added
        else                        // added
        {                           // added
            var didAct = await RunStep(config, cancellationToken);
            if (didAct)
            {
                lastOperationTime = Time.time;
            }
            else if (config.SecondsToErrorForNoInteractiveComponent > 0)
            {
                Assert.IsTrue(
                    (Time.time - lastOperationTime) < config.SecondsToErrorForNoInteractiveComponent,
                    $"Interactive component not found in {config.SecondsToErrorForNoInteractiveComponent} seconds"
                );
            }

            await UniTask.Delay(config.DelayMillis, DelayType.DeltaTime, cancellationToken: cancellationToken);
        }
    }
}
```

So, I cut out the part into a new public method `RunStep` from `Run`.