### PR TITLE
Fix MissingReferenceException

### DIFF
--- a/Runtime/Operators/TouchAndHoldOperator.cs
+++ b/Runtime/Operators/TouchAndHoldOperator.cs
@@ -30,8 +30,11 @@ namespace TestHelper.Monkey.Operators
             return interfaces.Contains(typeof(IPointerDownHandler)) && interfaces.Contains(typeof(IPointerUpHandler));
         }
 
-        internal static async Task TouchAndHold(MonoBehaviour component, int delayMillis = 1000,
-            CancellationToken cancellationToken = default)
+        internal static async Task TouchAndHold(
+            MonoBehaviour component,
+            int delayMillis = 1000,
+            CancellationToken cancellationToken = default
+        )
         {
             if (!(component is IPointerDownHandler downHandler) || !(component is IPointerUpHandler upHandler))
             {
@@ -45,6 +48,12 @@ namespace TestHelper.Monkey.Operators
 
             downHandler.OnPointerDown(eventData);
             await Task.Delay(delayMillis, cancellationToken);
+
+            if (component == null)
+            {
+                return;
+            }
+
             upHandler.OnPointerUp(eventData);
         }
     }

--- a/Tests/Runtime/Operators/TouchAndHoldOperatorTest.cs
+++ b/Tests/Runtime/Operators/TouchAndHoldOperatorTest.cs
@@ -27,6 +27,7 @@ namespace TestHelper.Monkey.Operators
 
         [TestCase("UsingOnPointerDownUpHandler", "OnPointerDown", "OnPointerUp")]
         [TestCase("UsingPointerDownUpEventTrigger", "ReceivePointerDown", "ReceivePointerUp")]
+        [TestCase("DestroyItselfIfPointerDown", "OnPointerDown", "DestroyImmediate")]
         public async Task TouchAndHold(string targetName, string expectedMessage1, string expectedMessage2)
         {
             var target = InteractiveComponentCollector.FindInteractiveComponents(false)

--- a/Tests/Runtime/TestDoubles/StubDestroyingItselfWhenPointerDown.cs
+++ b/Tests/Runtime/TestDoubles/StubDestroyingItselfWhenPointerDown.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace TestHelper.Monkey
+{
+    /// <summary>
+    /// Pointer down event handler
+    /// </summary>
+    [AddComponentMenu("")] // Hide from "Add Component" picker
+    public class StubDestroyingItselfWhenPointerDown : MonoBehaviour, IPointerDownHandler, IPointerUpHandler
+    {
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            var nameToKeepAfterGetDestroy = this.name;
+            Debug.Log($"{nameToKeepAfterGetDestroy}.{nameof(OnPointerDown)}");
+            DestroyImmediate(this.gameObject);
+            Debug.Log($"{nameToKeepAfterGetDestroy}.{nameof(DestroyImmediate)}");
+        }
+
+        public void OnPointerUp(PointerEventData eventData)
+        {
+            Debug.Log($"{this.name}.{nameof(OnPointerUp)}");
+        }
+    }
+}

--- a/Tests/Runtime/TestDoubles/StubDestroyingItselfWhenPointerDown.cs.meta
+++ b/Tests/Runtime/TestDoubles/StubDestroyingItselfWhenPointerDown.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7b1057c0c12f24021b73701c7a822fc3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Scenes/Operators.unity
+++ b/Tests/Scenes/Operators.unity
@@ -496,6 +496,126 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 4294967295
   m_MaxRayIntersections: 0
+--- !u!1 &819410219
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 819410225}
+  - component: {fileID: 819410224}
+  - component: {fileID: 819410223}
+  - component: {fileID: 819410222}
+  - component: {fileID: 819410220}
+  m_Layer: 0
+  m_Name: DestroyItselfIfPointerDown
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &819410220
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 819410219}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7b1057c0c12f24021b73701c7a822fc3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!65 &819410222
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 819410219}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &819410223
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 819410219}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &819410224
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 819410219}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &819410225
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 819410219}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &891015511
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
An interactive component that held by TouchAndHold can get destroyed ~after delayMilis elappsed~ **during delayMilis**. Then TouchAndHold throw the following error:

> MissingReferenceException: The object of type 'Button' has been
> destroyed but you are still trying to access it. Your script should
> either check if it is null or you should not destroy the object.

This patch introduce null-check after delayMilis elappsed.