### PR TITLE
Mod screen resolution specify for each class in tests

### DIFF
--- a/Tests/Runtime/AssemblyInfo.cs
+++ b/Tests/Runtime/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Copyright (c) 2023 Koji Hasegawa.
-// This software is released under the MIT License.
-
-using TestHelper.Attributes;
-
-[assembly: GameViewResolution(1920, 1080, "Full HD")]

--- a/Tests/Runtime/AssemblyInfo.cs.meta
+++ b/Tests/Runtime/AssemblyInfo.cs.meta
@@ -1,3 +1,0 @@
-fileFormatVersion: 2
-guid: ffe43f274be4417284caded05ffb84d7
-timeCreated: 1684587394

--- a/Tests/Runtime/InteractiveComponentCollectorTest.cs
+++ b/Tests/Runtime/InteractiveComponentCollectorTest.cs
@@ -16,6 +16,7 @@ namespace TestHelper.Monkey
         /// InteractiveComponentCollector test cases using 3D objects
         /// </summary>
         [TestFixture]
+        [GameViewResolution(GameViewResolution.VGA)]
         public class ThreeD
         {
             private const string TestScene =
@@ -64,6 +65,7 @@ namespace TestHelper.Monkey
         /// InteractiveComponentCollector test cases using 2D objects
         /// </summary>
         [TestFixture]
+        [GameViewResolution(GameViewResolution.VGA)]
         public class TwoD
         {
             private const string TestScene =
@@ -138,6 +140,7 @@ namespace TestHelper.Monkey
             /// InteractiveComponentCollector test cases using UI elements on screen-space-overlay canvas
             /// </summary>
             [TestFixture]
+            [GameViewResolution(GameViewResolution.FullHD)] // TODO: want to use VGA
             public class ScreenSpaceOverlay
             {
                 private const string TestScene =
@@ -182,6 +185,7 @@ namespace TestHelper.Monkey
             /// InteractiveComponentCollector test cases using UI elements on screen-space-camera canvas
             /// </summary>
             [TestFixture]
+            [GameViewResolution(GameViewResolution.FullHD)] // TODO: want to use VGA
             public class ScreenSpaceCamera
             {
                 private const string TestScene =
@@ -213,6 +217,8 @@ namespace TestHelper.Monkey
             /// <summary>
             /// InteractiveComponentCollector test cases using UI elements on world space canvas
             /// </summary>
+            [TestFixture]
+            [GameViewResolution(GameViewResolution.FullHD)] // TODO: want to use VGA
             public class WorldSpace
             {
                 private const string TestScene =

--- a/Tests/Runtime/InteractiveComponentTest.cs
+++ b/Tests/Runtime/InteractiveComponentTest.cs
@@ -18,6 +18,7 @@ namespace TestHelper.Monkey
         /// InteractiveComponent test cases using 3D objects
         /// </summary>
         [TestFixture]
+        [GameViewResolution(GameViewResolution.VGA)]
         public class ThreeD
         {
             private const string TestScene =
@@ -64,6 +65,7 @@ namespace TestHelper.Monkey
         /// InteractiveComponent test cases using UI elements
         /// </summary>
         [TestFixture]
+        [GameViewResolution(GameViewResolution.FullHD)] // TODO: want to use VGA
         public class UI
         {
             private const string TestScene =

--- a/Tests/Runtime/MonkeyTest.cs
+++ b/Tests/Runtime/MonkeyTest.cs
@@ -18,6 +18,7 @@ using UnityEngine.EventSystems;
 namespace TestHelper.Monkey
 {
     [TestFixture]
+    [GameViewResolution(GameViewResolution.VGA)]
     public class MonkeyTest
     {
         private const string TestScene = "Packages/com.nowsprinting.test-helper.monkey/Tests/Scenes/Operators.unity";

--- a/Tests/Runtime/Operators/ClickOperatorTest.cs
+++ b/Tests/Runtime/Operators/ClickOperatorTest.cs
@@ -10,6 +10,7 @@ using UnityEngine.TestTools;
 namespace TestHelper.Monkey.Operators
 {
     [TestFixture]
+    [GameViewResolution(GameViewResolution.VGA)]
     public class ClickOperatorTest
     {
         private const string TestScene = "Packages/com.nowsprinting.test-helper.monkey/Tests/Scenes/Operators.unity";

--- a/Tests/Runtime/Operators/TouchAndHoldOperatorTest.cs
+++ b/Tests/Runtime/Operators/TouchAndHoldOperatorTest.cs
@@ -11,6 +11,7 @@ using UnityEngine.TestTools;
 namespace TestHelper.Monkey.Operators
 {
     [TestFixture]
+    [GameViewResolution(GameViewResolution.VGA)]
     public class TouchAndHoldOperatorTest
     {
         private const string TestScene = "Packages/com.nowsprinting.test-helper.monkey/Tests/Scenes/Operators.unity";


### PR DESCRIPTION
In the future, I would like to standardize the screen resolution to VGA.

Currently, some scenes and tests need to be modified, so we will specify the screen resolution for each class so that only the necessary ones run in Full HD and the rest run in VGA.