### PR TITLE
Show hints for interactive components on SceneView and GameView (only if Gizmoz enabled)

### DIFF
--- a/Editor/ContextMenu.meta
+++ b/Editor/ContextMenu.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 11aadc9de8d0493ab7f059514fe906aa
+timeCreated: 1699053346

--- a/Editor/ContextMenu/HintComponentMenu.cs
+++ b/Editor/ContextMenu/HintComponentMenu.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using TestHelper.Monkey;
+using UnityEditor;
+using UnityEngine;
+
+namespace Editor.ContextMenu
+{
+    /// <summary>
+    /// Attaches interactive component hints
+    /// </summary>
+    public static class HintComponentMenu
+    {
+        [MenuItem("GameObject/TestHelper.Monkey/Interactive Component Hint Object")] // on Hierarchy window
+        private static void CreateInteractiveComponentHintObjectMenuItem()
+        {
+            new GameObject("Interactive Component Hint").AddComponent<InteractiveComponentHint>();
+        }
+    }
+}

--- a/Editor/ContextMenu/HintComponentMenu.cs.meta
+++ b/Editor/ContextMenu/HintComponentMenu.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d610fdbae5e44567842f29b17b601427
+timeCreated: 1699053355

--- a/Editor/Localization/ja.po
+++ b/Editor/Localization/ja.po
@@ -22,7 +22,7 @@ msgstr ""
 
 #: Editor/UI/Annotations/ScreenOffsetAnnotationEditor.cs
 
-# offset
+# label
 msgid "Offset"
 msgstr "オフセット"
 
@@ -33,7 +33,7 @@ msgstr "このコンポーネントが付属している GameObject のスクリ
 
 #: Editor/UI/Annotations/WorldOffsetAnnotationEditor.cs
 
-# offset
+# label
 msgid "Offset"
 msgstr "オフセット"
 
@@ -44,7 +44,7 @@ msgstr "このコンポーネントが付属している GameObject のワール
 
 #: Editor/UI/Annotations/ScreenPositionAnnotationEditor.cs
 
-# offset
+# label
 msgid "Position"
 msgstr "位置"
 
@@ -55,10 +55,45 @@ msgstr "このコンポーネントが付属している GameObject に対する
 
 #: Editor/UI/Annotations/WorldPositionAnnotationEditor.cs
 
-# offset
+# label
 msgid "Position"
 msgstr "位置"
 
 # description tooltip
 msgid "A world position that where monkey operators operate on"
 msgstr "このコンポーネントが付属している GameObject に対するモンキー操作をするスクリーン座標"
+
+
+#: Editor/UI/Hints/InteractiveComponentHintEditor.cs
+
+# label
+msgid "Active Point"
+msgstr "操作可能点"
+
+# description tooltip
+msgid "Color for interactive components that user can operate"
+msgstr "インタラクティブなコンポーネントのうちユーザーが操作可能なものの色"
+
+# label
+msgid "Inactive Point"
+msgstr "操作不能点"
+
+# description tooltip
+msgid "Color for interactive components that user cannot operate"
+msgstr "インタラクティブなコンポーネントのうちユーザーが操作不能なものの色"
+
+# label
+msgid "Original Point"
+msgstr "基準点"
+
+# description tooltip
+msgid "Color for the default operation point for interactive components that is used for the origin point of position annotations"
+msgstr "インタラクティブなコンポーネントに対するアノテーションの基準位置の色"
+
+# label
+msgid "Frames/Refresh"
+msgstr "フレーム数/更新"
+
+# description tooltip
+msgid "Number of frames per refresh hints"
+msgstr "何フレームごとにヒントを更新するか"

--- a/Editor/Localization/ja.po
+++ b/Editor/Localization/ja.po
@@ -67,28 +67,28 @@ msgstr "このコンポーネントが付属している GameObject に対する
 #: Editor/UI/Hints/InteractiveComponentHintEditor.cs
 
 # label
-msgid "Active Point"
-msgstr "操作可能点"
+msgid "Corrected Point (reachable)"
+msgstr "操作可能点（補正済）"
 
 # description tooltip
-msgid "Color for interactive components that user can operate"
-msgstr "インタラクティブなコンポーネントのうちユーザーが操作可能なものの色"
+msgid "Color for corrected points of interactive components that monkey operators can operate"
+msgstr "ユーザーが操作可能なインタラクティブコンポーネントの補正済み操作位置の色"
 
 # label
-msgid "Inactive Point"
-msgstr "操作不能点"
+msgid "Corrected Point (unreachable)"
+msgstr "操作不能点（補正済）"
 
 # description tooltip
-msgid "Color for interactive components that user cannot operate"
-msgstr "インタラクティブなコンポーネントのうちユーザーが操作不能なものの色"
+msgid "Color for corrected points of interactive components that monkey operators cannot operate"
+msgstr "ユーザーが操作不能なインタラクティブコンポーネントの補正済み操作位置の色"
 
 # label
 msgid "Original Point"
-msgstr "基準点"
+msgstr "補正基準点"
 
 # description tooltip
-msgid "Color for the default operation point for interactive components that is used for the origin point of position annotations"
-msgstr "インタラクティブなコンポーネントに対するアノテーションの基準位置の色"
+msgid "Color for default operation points for interactive components that is used for the origin point of position annotations"
+msgstr "インタラクティブなコンポーネントに対する位置補正アノテーションの基準位置の色"
 
 # label
 msgid "Frames/Refresh"

--- a/Editor/TestHelper.Monkey.Editor.asmdef
+++ b/Editor/TestHelper.Monkey.Editor.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "TestHelper.Monkey.Editor",
     "references": [
-        "TestHelper.Monkey.Annotations"
+        "TestHelper.Monkey.Annotations",
+        "TestHelper.Monkey"
     ],
     "includePlatforms": [
         "Editor"

--- a/Editor/UI/Hints.meta
+++ b/Editor/UI/Hints.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7727467ca7384559a2f4999c276eb340
+timeCreated: 1698901129

--- a/Editor/UI/Hints/InteractiveComponentHintEditor.cs
+++ b/Editor/UI/Hints/InteractiveComponentHintEditor.cs
@@ -12,26 +12,26 @@ namespace TestHelper.Monkey.Editor.Hints
     [CustomEditor(typeof(InteractiveComponentHint))]
     public class InteractiveComponentHintEditor : UnityEditor.Editor
     {
-        private static readonly string s_activePointColor = L10n.Tr("Active Point");
+        private static readonly string s_reachablePointColor = L10n.Tr("Corrected Point (reachable)");
 
-        private static readonly string s_activePointTooltip =
-            L10n.Tr("Color for interactive components that user can operate");
+        private static readonly string s_reachablePointTooltip =
+            L10n.Tr("Color for corrected points of interactive components that monkey operators can operate");
 
-        private SerializedProperty _activePointColorProp;
-        private GUIContent _activePointColorContent;
+        private SerializedProperty _reachablePointColorProp;
+        private GUIContent _reachablePointColorContent;
 
-        private static readonly string s_inactiveColor = L10n.Tr("Inactive Point");
+        private static readonly string s_unreachableColor = L10n.Tr("Corrected Point (unreachable)");
 
-        private static readonly string s_inactiveTooltip =
-            L10n.Tr("Color for interactive components that user cannot operate");
+        private static readonly string s_unreachableTooltip =
+            L10n.Tr("Color for corrected points of interactive components that monkey operators cannot operate");
 
-        private SerializedProperty _inactivePointColorProp;
-        private GUIContent _inactivePointColorContent;
+        private SerializedProperty _unreachablePointColorProp;
+        private GUIContent _unreachablePointColorContent;
 
         private static readonly string s_originalPointColor = L10n.Tr("Original Point");
 
         private static readonly string s_originalPointTooltip = L10n.Tr(
-            "Color for the default operation point for interactive components that is used for the origin point of position annotations"
+            "Color for default operation points for interactive components that is used for the origin point of position annotations"
         );
 
         private SerializedProperty _originalPointColorProp;
@@ -45,11 +45,11 @@ namespace TestHelper.Monkey.Editor.Hints
 
         private void OnEnable()
         {
-            _activePointColorProp = serializedObject.FindProperty(nameof(InteractiveComponentHint.activePointColor));
-            _activePointColorContent = new GUIContent(s_activePointColor, s_activePointTooltip);
-            _inactivePointColorProp =
-                serializedObject.FindProperty(nameof(InteractiveComponentHint.inactivePointColor));
-            _inactivePointColorContent = new GUIContent(s_inactiveColor, s_inactiveTooltip);
+            _reachablePointColorProp = serializedObject.FindProperty(nameof(InteractiveComponentHint.reachableColor));
+            _reachablePointColorContent = new GUIContent(s_reachablePointColor, s_reachablePointTooltip);
+            _unreachablePointColorProp =
+                serializedObject.FindProperty(nameof(InteractiveComponentHint.unreachableColor));
+            _unreachablePointColorContent = new GUIContent(s_unreachableColor, s_unreachableTooltip);
             _originalPointColorProp = serializedObject.FindProperty(nameof(InteractiveComponentHint.originalPointColor));
             _originalPointColorContent = new GUIContent(s_originalPointColor, s_originalPointTooltip);
             _refreshFrameCountProp = serializedObject.FindProperty(nameof(InteractiveComponentHint.framesPerRefresh));
@@ -61,8 +61,8 @@ namespace TestHelper.Monkey.Editor.Hints
         {
             serializedObject.Update();
 
-            EditorGUILayout.PropertyField(_activePointColorProp, _activePointColorContent);
-            EditorGUILayout.PropertyField(_inactivePointColorProp, _inactivePointColorContent);
+            EditorGUILayout.PropertyField(_reachablePointColorProp, _reachablePointColorContent);
+            EditorGUILayout.PropertyField(_unreachablePointColorProp, _unreachablePointColorContent);
             EditorGUILayout.PropertyField(_originalPointColorProp, _originalPointColorContent);
             EditorGUILayout.PropertyField(_refreshFrameCountProp, _refreshFrameCountContent);
 

--- a/Editor/UI/Hints/InteractiveComponentHintEditor.cs
+++ b/Editor/UI/Hints/InteractiveComponentHintEditor.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using UnityEditor;
+using UnityEngine;
+
+namespace TestHelper.Monkey.Editor.Hints
+{
+    /// <summary>
+    /// Custom editor for <c cref="InteractiveComponentHint" />
+    /// </summary>
+    [CustomEditor(typeof(InteractiveComponentHint))]
+    public class InteractiveComponentHintEditor : UnityEditor.Editor
+    {
+        private static readonly string s_activePointColor = L10n.Tr("Active Point");
+
+        private static readonly string s_activePointTooltip =
+            L10n.Tr("Color for interactive components that user can operate");
+
+        private SerializedProperty _activePointColorProp;
+        private GUIContent _activePointColorContent;
+
+        private static readonly string s_inactiveColor = L10n.Tr("Inactive Point");
+
+        private static readonly string s_inactiveTooltip =
+            L10n.Tr("Color for interactive components that user cannot operate");
+
+        private SerializedProperty _inactivePointColorProp;
+        private GUIContent _inactivePointColorContent;
+
+        private static readonly string s_originalPointColor = L10n.Tr("Original Point");
+
+        private static readonly string s_originalPointTooltip = L10n.Tr(
+            "Color for the default operation point for interactive components that is used for the origin point of position annotations"
+        );
+
+        private SerializedProperty _originalPointColorProp;
+        private GUIContent _originalPointColorContent;
+
+        private static readonly string s_refreshFrameCount = L10n.Tr("Frames/Refresh");
+        private static readonly string s_refreshFrameCountTooltip = L10n.Tr("Number of frames per refresh hints");
+        private SerializedProperty _refreshFrameCountProp;
+        private GUIContent _refreshFrameCountContent;
+
+
+        private void OnEnable()
+        {
+            _activePointColorProp = serializedObject.FindProperty(nameof(InteractiveComponentHint.activePointColor));
+            _activePointColorContent = new GUIContent(s_activePointColor, s_activePointTooltip);
+            _inactivePointColorProp =
+                serializedObject.FindProperty(nameof(InteractiveComponentHint.inactivePointColor));
+            _inactivePointColorContent = new GUIContent(s_inactiveColor, s_inactiveTooltip);
+            _originalPointColorProp = serializedObject.FindProperty(nameof(InteractiveComponentHint.originalPointColor));
+            _originalPointColorContent = new GUIContent(s_originalPointColor, s_originalPointTooltip);
+            _refreshFrameCountProp = serializedObject.FindProperty(nameof(InteractiveComponentHint.framesPerRefresh));
+            _refreshFrameCountContent = new GUIContent(s_refreshFrameCount, s_refreshFrameCountTooltip);
+        }
+
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.PropertyField(_activePointColorProp, _activePointColorContent);
+            EditorGUILayout.PropertyField(_inactivePointColorProp, _inactivePointColorContent);
+            EditorGUILayout.PropertyField(_originalPointColorProp, _originalPointColorContent);
+            EditorGUILayout.PropertyField(_refreshFrameCountProp, _refreshFrameCountContent);
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Editor/UI/Hints/InteractiveComponentHintEditor.cs.meta
+++ b/Editor/UI/Hints/InteractiveComponentHintEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 09b0ea64fe8b443c9fd0c0c8b2563250
+timeCreated: 1698901149

--- a/Editor/UI/Hints/InteractiveComponentHintGizmoDrawer.cs
+++ b/Editor/UI/Hints/InteractiveComponentHintGizmoDrawer.cs
@@ -34,9 +34,9 @@ namespace Editor.UI
             {
                 var (worldPoint, camNorm) = worldPointAndLabel.Key;
                 var label = worldPointAndLabel.Value;
-                Handles.color = hint.inactivePointColor;
+                Handles.color = hint.unreachableColor;
                 Handles.DrawWireDisc(worldPoint, camNorm, 0.1f);
-                GUI.color = hint.inactivePointColor;
+                GUI.color = hint.unreachableColor;
                 Handles.Label(worldPoint + s_labelOffset, label);
             }
             
@@ -44,9 +44,9 @@ namespace Editor.UI
             {
                 var (worldPoint, camNorm) = worldPointAndLabel.Key;
                 var label = worldPointAndLabel.Value;
-                Handles.color = hint.activePointColor;
+                Handles.color = hint.reachableColor;
                 Handles.DrawWireDisc(worldPoint, camNorm, 0.1f);
-                GUI.color = hint.activePointColor;
+                GUI.color = hint.reachableColor;
                 Handles.Label(worldPoint + s_labelOffset, label);
             }
         }

--- a/Editor/UI/Hints/InteractiveComponentHintGizmoDrawer.cs
+++ b/Editor/UI/Hints/InteractiveComponentHintGizmoDrawer.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using TestHelper.Monkey;
+using UnityEditor;
+using UnityEngine;
+
+namespace Editor.UI
+{
+    /// <summary>
+    /// Gizmo Drawer for <c cref="InteractiveComponentHint" />
+    /// </summary>
+    public static class InteractiveComponentHintGizmoDrawer
+    {
+        private static readonly Vector3 s_labelOffset = new Vector3(0.1f, 0, 0);
+
+        // ReSharper disable once BitwiseOperatorOnEnumWithoutFlags
+        [DrawGizmo(GizmoType.NonSelected | GizmoType.Selected)]
+        private static void OnDrawGizmos(InteractiveComponentHint hint, GizmoType _)
+        {
+            if (!hint.enabled)
+            {
+                return;
+            }
+
+            foreach (var (origPoint, camNorm, worldPoint) in hint.OriginalRelation)
+            {
+                Handles.color = hint.originalPointColor;
+                Handles.DrawWireDisc(origPoint, camNorm, 0.1f);
+                Handles.DrawLine(origPoint, worldPoint);
+            }
+
+            foreach (var worldPointAndLabel in hint.NotReallyInteractives)
+            {
+                var (worldPoint, camNorm) = worldPointAndLabel.Key;
+                var label = worldPointAndLabel.Value;
+                Handles.color = hint.inactivePointColor;
+                Handles.DrawWireDisc(worldPoint, camNorm, 0.1f);
+                GUI.color = hint.inactivePointColor;
+                Handles.Label(worldPoint + s_labelOffset, label);
+            }
+            
+            foreach (var worldPointAndLabel in hint.ReallyInteractives)
+            {
+                var (worldPoint, camNorm) = worldPointAndLabel.Key;
+                var label = worldPointAndLabel.Value;
+                Handles.color = hint.activePointColor;
+                Handles.DrawWireDisc(worldPoint, camNorm, 0.1f);
+                GUI.color = hint.activePointColor;
+                Handles.Label(worldPoint + s_labelOffset, label);
+            }
+        }
+    }
+}

--- a/Editor/UI/Hints/InteractiveComponentHintGizmoDrawer.cs.meta
+++ b/Editor/UI/Hints/InteractiveComponentHintGizmoDrawer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 14c458212ef94846b2b487b2819ccef7
+timeCreated: 1698797934

--- a/Runtime/CameraSelector.cs
+++ b/Runtime/CameraSelector.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using UnityEngine;
+
+namespace TestHelper.Monkey
+{
+    /// <summary>
+    /// A utility to select Camera
+    /// </summary>
+    public static class CameraSelector
+    {
+        private static Camera s_cachedMainCamera;
+        private static int s_cachedFrame;
+
+        /// <summary>
+        /// Returns the first enabled Camera component that is tagged "MainCamera"
+        /// </summary>
+        /// <returns>The first enabled Camera component that is tagged "MainCamera"</returns>
+        public static Camera GetMainCamera()
+        {
+            if (Time.frameCount == s_cachedFrame)
+            {
+                return s_cachedMainCamera;
+            }
+
+            s_cachedFrame = Time.frameCount;
+            return s_cachedMainCamera = Camera.main;
+        }
+
+        /// <summary>
+        /// Returns an associated camera with <paramref name="gameObject"/>. Or return <c cref="Camera.main" /> if
+        /// there are no camera associated with
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <returns>
+        /// Camera associated with <paramref name="gameObject"/>, or return <c cref="Camera.main" /> if there are
+        /// no camera associated with
+        /// </returns>
+        public static Camera SelectBy(GameObject gameObject)
+        {
+            var canvas = gameObject.GetComponentInParent<Canvas>();
+            if (canvas == null)
+            {
+                return GetMainCamera();
+            }
+
+            if (!canvas.isRootCanvas)
+            {
+                canvas = canvas.rootCanvas;
+            }
+
+            return canvas.renderMode == RenderMode.ScreenSpaceOverlay ? null : canvas.worldCamera;
+        }
+    }
+}

--- a/Runtime/CameraSelector.cs.meta
+++ b/Runtime/CameraSelector.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a1c10c25a23546e7b668fdade0c29358
+timeCreated: 1698925664

--- a/Runtime/Hints.meta
+++ b/Runtime/Hints.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 84f01583a04345e7a0d7e4116745d455
+timeCreated: 1698904800

--- a/Runtime/Hints/InteractiveComponentHint.cs
+++ b/Runtime/Hints/InteractiveComponentHint.cs
@@ -19,7 +19,7 @@ namespace TestHelper.Monkey
         /// Color for interactive components that users can operate
         /// </summary>
         [SerializeField]
-        public Color reachableColor = Color.yellow;
+        public Color reachableColor = Color.blue;
 
         /// <summary>
         /// Color for interactive components that users cannot operate

--- a/Runtime/Hints/InteractiveComponentHint.cs
+++ b/Runtime/Hints/InteractiveComponentHint.cs
@@ -17,7 +17,7 @@ namespace TestHelper.Monkey
         /// Color for interactive components that users can operate
         /// </summary>
         [SerializeField]
-        public Color activePointColor = Color.blue;
+        public Color reachableColor = Color.yellow;
 
         /// <summary>
         /// Color for interactive components that users cannot operate

--- a/Runtime/Hints/InteractiveComponentHint.cs
+++ b/Runtime/Hints/InteractiveComponentHint.cs
@@ -61,8 +61,6 @@ namespace TestHelper.Monkey
         /// </summary>
         public IReadOnlyList<(Vector3, Vector3, Vector3)> OriginalRelation => _originalRel;
 
-        private int _count;
-
         private readonly StringBuilder _sb = new StringBuilder();
 
         private readonly Dictionary<(Vector3, Vector3), string> _notReallyInteractives =

--- a/Runtime/Hints/InteractiveComponentHint.cs
+++ b/Runtime/Hints/InteractiveComponentHint.cs
@@ -13,6 +13,8 @@ namespace TestHelper.Monkey
     /// </summary>
     public class InteractiveComponentHint : MonoBehaviour
     {
+        private static readonly Color s_orange = new Color(0xef, 0x81, 0x0f);
+        
         /// <summary>
         /// Color for interactive components that users can operate
         /// </summary>
@@ -23,7 +25,7 @@ namespace TestHelper.Monkey
         /// Color for interactive components that users cannot operate
         /// </summary>
         [SerializeField]
-        public Color unreachableColor = new Color(0xef, 0x81, 0x0f);
+        public Color unreachableColor = s_orange;
 
         /// <summary>
         /// Color for points that is the origin of position annotations
@@ -37,14 +39,12 @@ namespace TestHelper.Monkey
         [SerializeField]
         public int framesPerRefresh = 100;
 
-
         /// <summary>
         /// Screen point strategy. You should use a same strategy that monkey operators use.
         /// </summary>
         /// <param name="go">GameObject where monkey operators operate on</param>
         /// <returns></returns>
         public virtual Vector2 GetScreenPoint(GameObject go) => DefaultScreenPointStrategy.GetScreenPoint(go);
-
 
         /// <summary>
         /// Operation point and the hint texts for interactive components that users cannot operate
@@ -82,7 +82,6 @@ namespace TestHelper.Monkey
         private readonly Dictionary<(Vector3, Vector3), HashSet<GameObject>> _tmpReallyInteractives =
             new Dictionary<(Vector3, Vector3), HashSet<GameObject>>();
 
-
         private void Start()
         {
             Refresh();
@@ -95,7 +94,6 @@ namespace TestHelper.Monkey
                 Refresh();
             }
         }
-
 
         private void Refresh()
         {
@@ -130,7 +128,6 @@ namespace TestHelper.Monkey
             RefreshLabels();
         }
 
-
         private void Clear()
         {
             _reallyInteractives.Clear();
@@ -147,7 +144,6 @@ namespace TestHelper.Monkey
                 worldPointAndGameObjects.Value.Clear();
             }
         }
-
 
         private void RefreshLabels()
         {

--- a/Runtime/Hints/InteractiveComponentHint.cs
+++ b/Runtime/Hints/InteractiveComponentHint.cs
@@ -23,7 +23,7 @@ namespace TestHelper.Monkey
         /// Color for interactive components that users cannot operate
         /// </summary>
         [SerializeField]
-        public Color inactivePointColor = Color.red;
+        public Color unreachableColor = new Color(0xef, 0x81, 0x0f);
 
         /// <summary>
         /// Color for points that is the origin of position annotations

--- a/Runtime/Hints/InteractiveComponentHint.cs
+++ b/Runtime/Hints/InteractiveComponentHint.cs
@@ -1,0 +1,191 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Collections.Generic;
+using System.Text;
+using TestHelper.Monkey.ScreenPointStrategies;
+using UnityEngine;
+
+namespace TestHelper.Monkey
+{
+    /// <summary>
+    /// Component to make operation positions visible
+    /// </summary>
+    public class InteractiveComponentHint : MonoBehaviour
+    {
+        /// <summary>
+        /// Color for interactive components that users can operate
+        /// </summary>
+        [SerializeField]
+        public Color activePointColor = Color.blue;
+
+        /// <summary>
+        /// Color for interactive components that users cannot operate
+        /// </summary>
+        [SerializeField]
+        public Color inactivePointColor = Color.red;
+
+        /// <summary>
+        /// Color for points that is the origin of position annotations
+        /// </summary>
+        [SerializeField]
+        public Color originalPointColor = Color.gray;
+
+        /// <summary>
+        /// Number of frames per refresh hints
+        /// </summary>
+        [SerializeField]
+        public int framesPerRefresh = 100;
+
+
+        /// <summary>
+        /// Screen point strategy. You should use a same strategy that monkey operators use.
+        /// </summary>
+        /// <param name="go">GameObject where monkey operators operate on</param>
+        /// <returns></returns>
+        public virtual Vector2 GetScreenPoint(GameObject go) => DefaultScreenPointStrategy.GetScreenPoint(go);
+
+
+        /// <summary>
+        /// Operation point and the hint texts for interactive components that users cannot operate
+        /// </summary>
+        public IReadOnlyDictionary<(Vector3, Vector3), string> NotReallyInteractives => _notReallyInteractives;
+
+        /// <summary>
+        /// Operation point and the hint texts for interactive components that users can operate
+        /// </summary>
+        public IReadOnlyDictionary<(Vector3, Vector3), string> ReallyInteractives => _reallyInteractives;
+
+        /// <summary>
+        /// Relation between an origin point for annotations and the operation point.
+        /// </summary>
+        public IReadOnlyList<(Vector3, Vector3, Vector3)> OriginalRelation => _originalRel;
+
+        private int _count;
+
+        private readonly StringBuilder _sb = new StringBuilder();
+
+        private readonly Dictionary<(Vector3, Vector3), string> _notReallyInteractives =
+            new Dictionary<(Vector3, Vector3), string>();
+
+        private readonly Dictionary<(Vector3, Vector3), string> _reallyInteractives =
+            new Dictionary<(Vector3, Vector3), string>();
+
+        /// <summary>
+        /// Triples of an original world point and a camera normal vector and the modified world point
+        /// </summary>
+        private readonly List<(Vector3, Vector3, Vector3)> _originalRel = new List<(Vector3, Vector3, Vector3)>();
+
+        private readonly Dictionary<(Vector3, Vector3), HashSet<GameObject>> _tmpNotReallyInteractives =
+            new Dictionary<(Vector3, Vector3), HashSet<GameObject>>();
+
+        private readonly Dictionary<(Vector3, Vector3), HashSet<GameObject>> _tmpReallyInteractives =
+            new Dictionary<(Vector3, Vector3), HashSet<GameObject>>();
+
+
+        private void Update()
+        {
+            if (_count == 0)
+            {
+                Refresh();
+                _count = framesPerRefresh;
+            }
+            else
+            {
+                _count--;
+            }
+        }
+
+
+        private void Refresh()
+        {
+            Clear();
+
+            foreach (var component in InteractiveComponentCollector.FindInteractiveComponents())
+            {
+                var dst = component.IsReallyInteractiveFromUser(GetScreenPoint)
+                    ? _tmpReallyInteractives
+                    : _tmpNotReallyInteractives;
+
+                var screenPoint = GetScreenPoint(component.gameObject);
+                var originalPos = component.transform.position;
+                var modifiedPos = InteractiveComponentHintPosition.GetWorldPoint(
+                    CameraSelector.SelectBy(component.gameObject),
+                    screenPoint,
+                    originalPos
+                );
+
+                var cameraNorm = CameraSelector.SelectBy(component.gameObject)?.transform.forward * -1 ?? Vector3.back;
+
+                if (!dst.TryGetValue((modifiedPos, cameraNorm), out var gameObjects))
+                {
+                    gameObjects = dst[(modifiedPos, cameraNorm)] = new HashSet<GameObject>();
+                }
+
+                gameObjects.Add(component.gameObject);
+
+                _originalRel.Add((originalPos, cameraNorm, modifiedPos));
+            }
+
+            RefreshLabels();
+        }
+
+
+        private void Clear()
+        {
+            _reallyInteractives.Clear();
+            _notReallyInteractives.Clear();
+            _originalRel.Clear();
+
+            foreach (var worldPointAndGameObjects in _tmpReallyInteractives)
+            {
+                worldPointAndGameObjects.Value.Clear();
+            }
+
+            foreach (var worldPointAndGameObjects in _tmpNotReallyInteractives)
+            {
+                worldPointAndGameObjects.Value.Clear();
+            }
+        }
+
+
+        private void RefreshLabels()
+        {
+            foreach (var worldPointAndGameObjects in _tmpReallyInteractives)
+            {
+                var worldPoint = worldPointAndGameObjects.Key;
+                var gameObjects = worldPointAndGameObjects.Value;
+                if (gameObjects.Count == 0)
+                {
+                    continue;
+                }
+
+                _sb.Clear();
+                foreach (var go in gameObjects)
+                {
+                    _sb.AppendLine(go.name);
+                }
+
+                _reallyInteractives[worldPoint] = _sb.ToString();
+            }
+
+            foreach (var worldPointAndGameObjects in _tmpNotReallyInteractives)
+            {
+                var worldPoint = worldPointAndGameObjects.Key;
+                var gameObjects = worldPointAndGameObjects.Value;
+                if (gameObjects.Count == 0)
+                {
+                    continue;
+                }
+
+                _sb.Clear();
+                foreach (var go in gameObjects)
+                {
+                    _sb.AppendLine(go.name);
+                }
+
+                _notReallyInteractives[worldPoint] = _sb.ToString();
+            }
+        }
+    }
+}

--- a/Runtime/Hints/InteractiveComponentHint.cs
+++ b/Runtime/Hints/InteractiveComponentHint.cs
@@ -83,16 +83,16 @@ namespace TestHelper.Monkey
             new Dictionary<(Vector3, Vector3), HashSet<GameObject>>();
 
 
+        private void Start()
+        {
+            Refresh();
+        }
+
         private void Update()
         {
-            if (_count == 0)
+            if (Time.frameCount % framesPerRefresh == 0)
             {
                 Refresh();
-                _count = framesPerRefresh;
-            }
-            else
-            {
-                _count--;
             }
         }
 

--- a/Runtime/Hints/InteractiveComponentHint.cs.meta
+++ b/Runtime/Hints/InteractiveComponentHint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe4a094b2123f426dbd35f67018724cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Hints/InteractiveComponentHintPosition.cs
+++ b/Runtime/Hints/InteractiveComponentHintPosition.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using UnityEngine;
+
+namespace TestHelper.Monkey
+{
+    /// <summary>
+    /// Utility for calculating position for interactive component hints
+    /// </summary>
+    public static class InteractiveComponentHintPosition
+    {
+        /// <summary>
+        /// Get operation point in world space where monkey operators operate on
+        /// the <paramref name="camera"/>.
+        /// </summary>
+        /// <param name="camera">Camera used by EventSystems</param>
+        /// <param name="screenPoint">Screen point got by screen position strategies</param>
+        /// <param name="targetPos">World space position for the hint target</param>
+        /// <returns></returns>
+        public static Vector3 GetWorldPoint(Camera camera, Vector2 screenPoint, Vector3 targetPos)
+        {
+            var screenSpaceOverlay = camera == null;
+            if (screenSpaceOverlay)
+            {
+                return screenPoint;
+            }
+
+            var camTransform = camera.transform;
+
+            if (camera.orthographic)
+            {
+                var originalScreenPoint = (Vector2)camera.WorldToScreenPoint(targetPos);
+                var unitPerPx = camera.orthographicSize * 2 / Screen.height;
+                var d = (screenPoint - originalScreenPoint) * unitPerPx;
+                return targetPos + camTransform.right * d.x + camTransform.up * d.y;
+            }
+
+            var camBack = camTransform.forward * -1;
+            var camPos = camTransform.position;
+
+            // Ray is a direction vector from the camera position to the operation point in world space
+            var anyPointInRay = camera.ScreenToWorldPoint(new Vector3(screenPoint.x, screenPoint.y, 1));
+            var rayDirection = (anyPointInRay - camPos).normalized;
+            var x = Vector3.Dot(camBack, targetPos);
+            return camPos + (x - Vector3.Dot(camBack, camPos)) / Vector3.Dot(camBack, rayDirection) * rayDirection;
+        }
+    }
+}

--- a/Runtime/Hints/InteractiveComponentHintPosition.cs.meta
+++ b/Runtime/Hints/InteractiveComponentHintPosition.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d6167fe786e240f18f02b894a2de24f9
+timeCreated: 1698903959

--- a/Runtime/InteractiveComponent.cs
+++ b/Runtime/InteractiveComponent.cs
@@ -70,6 +70,10 @@ namespace TestHelper.Monkey
             results = results ?? new List<RaycastResult>();
             results.Clear();
 
+            if (EventSystem.current == null)
+            {
+                return false;
+            }
             EventSystem.current.RaycastAll(eventData, results);
             return results.Count > 0 && IsSameOrChildObject(results[0].gameObject.transform);
         }

--- a/Runtime/ScreenPointStrategies/GameObjectPosition.cs
+++ b/Runtime/ScreenPointStrategies/GameObjectPosition.cs
@@ -15,10 +15,8 @@ namespace TestHelper.Monkey.ScreenPointStrategies
         /// </summary>
         /// <param name="gameObject">GameObject that monkey operators operate</param>
         /// <returns>The screen point of the <paramref name="gameObject"/> transform position</returns>
-        public static Vector2 GetScreenPoint(GameObject gameObject)
-        {
-            return GetScreenPointByWorldPosition(gameObject, gameObject.transform.position);
-        }
+        public static Vector2 GetScreenPoint(GameObject gameObject) =>
+            GetScreenPointByWorldPosition(gameObject, gameObject.transform.position);
 
         /// <summary>
         /// Returns 
@@ -26,41 +24,7 @@ namespace TestHelper.Monkey.ScreenPointStrategies
         /// <param name="gameObject">GameObject that monkey operators operate</param>
         /// <param name="pos">The world position where monkey operators operate on</param>
         /// <returns>The screen point of the <paramref name="pos"/></returns>
-        public static Vector2 GetScreenPointByWorldPosition(GameObject gameObject, Vector3 pos)
-        {
-            var canvas = gameObject.GetComponentInParent<Canvas>();
-            if (canvas != null)
-            {
-                if (!canvas.isRootCanvas)
-                {
-                    canvas = canvas.rootCanvas;
-                }
-
-                if (canvas.renderMode == RenderMode.ScreenSpaceOverlay)
-                {
-                    return RectTransformUtility.WorldToScreenPoint(null, pos);
-                }
-
-                return RectTransformUtility.WorldToScreenPoint(canvas.worldCamera, pos);
-            }
-
-            return RectTransformUtility.WorldToScreenPoint(GetMainCamera(), pos);
-        }
-
-
-        private static Camera s_cachedMainCamera;
-        private static int s_cachedFrame;
-
-
-        private static Camera GetMainCamera()
-        {
-            if (Time.frameCount == s_cachedFrame)
-            {
-                return s_cachedMainCamera;
-            }
-
-            s_cachedFrame = Time.frameCount;
-            return s_cachedMainCamera = Camera.main;
-        }
+        public static Vector2 GetScreenPointByWorldPosition(GameObject gameObject, Vector3 pos) =>
+            RectTransformUtility.WorldToScreenPoint(CameraSelector.SelectBy(gameObject), pos);
     }
 }

--- a/Tests/Runtime/Hints.meta
+++ b/Tests/Runtime/Hints.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e221dd181424459db41da5825b2e1998
+timeCreated: 1698905423

--- a/Tests/Runtime/Hints/InteractiveComponentHintPositionTest.cs
+++ b/Tests/Runtime/Hints/InteractiveComponentHintPositionTest.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Linq;
+using NUnit.Framework;
+using TestHelper.Attributes;
+using TestHelper.Monkey.ScreenPointStrategies;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools.Utils;
+
+namespace TestHelper.Monkey.Hints
+{
+    [TestFixture]
+    [GameViewResolution(GameViewResolution.VGA)]
+    public class InteractiveComponentHintPositionTest
+    {
+        private const string TestScene = "Packages/com.nowsprinting.test-helper.monkey/Tests/Scenes/Hints.unity";
+
+        [TestCase("Left Cube", -1f, 0, 0)]
+        [TestCase("Right Cube", 2f, 0, 0)]
+        [TestCase("Left Cube", -1f, 0, 0)]
+        [TestCase("Right Cube", 2f, 0, 0)]
+        [LoadScene(TestScene)]
+        public void Get(string targetName, float x, float y , float z)
+        {
+            var camera = Camera.main;
+            var target = SceneManager
+                .GetActiveScene()
+                .GetRootGameObjects()
+                .First(go => go.name == targetName);
+            var screenPoint = DefaultScreenPointStrategy.GetScreenPoint(target);
+
+            var actual = InteractiveComponentHintPosition.GetWorldPoint(camera, screenPoint, target.transform.position);
+            var expected = new Vector3(x, y, z);
+            var msg = $"Actual: {actual.ToString("F4")}\nExpected: {expected.ToString("F4")}";
+            Assert.That(actual, Is.EqualTo(expected).Using(Vector3EqualityComparer.Instance), msg);
+        }
+    }
+}

--- a/Tests/Runtime/Hints/InteractiveComponentHintPositionTest.cs.meta
+++ b/Tests/Runtime/Hints/InteractiveComponentHintPositionTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 941966e4cc1f43de96dede86342a71d2
+timeCreated: 1698905015

--- a/Tests/Runtime/TestDoubles/SpyOnPointerDownUpHandler.cs
+++ b/Tests/Runtime/TestDoubles/SpyOnPointerDownUpHandler.cs
@@ -10,7 +10,6 @@ namespace TestHelper.Monkey.TestDoubles
     /// <summary>
     /// Pointer down/up event handler
     /// </summary>
-    [AddComponentMenu("")] // Hide from "Add Component" picker
     internal class SpyOnPointerDownUpHandler : MonoBehaviour, IPointerDownHandler, IPointerUpHandler
     {
         private void Log([CallerMemberName] string member = "")

--- a/Tests/Runtime/TestDoubles/SpyOnPointerDownUpHandler.cs
+++ b/Tests/Runtime/TestDoubles/SpyOnPointerDownUpHandler.cs
@@ -10,6 +10,7 @@ namespace TestHelper.Monkey.TestDoubles
     /// <summary>
     /// Pointer down/up event handler
     /// </summary>
+    [AddComponentMenu("")] // Hide from "Add Component" picker
     internal class SpyOnPointerDownUpHandler : MonoBehaviour, IPointerDownHandler, IPointerUpHandler
     {
         private void Log([CallerMemberName] string member = "")

--- a/Tests/Scenes/Annotations.unity
+++ b/Tests/Scenes/Annotations.unity
@@ -38,12 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481676, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028305, g: 0.22571313, b: 0.3069213, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
+  serializedVersion: 11
   m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -98,13 +98,13 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_LightingSettings: {fileID: 4890085278179872738, guid: 8d57e92d5a0aa483aa2e82079debadfe, type: 2}
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
-    serializedVersion: 3
+    serializedVersion: 2
     agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
@@ -117,9 +117,7 @@ NavMeshSettings:
     cellSize: 0.16666667
     manualTileSize: 0
     tileSize: 256
-    buildHeightMesh: 0
-    maxJobWorkers: 0
-    preserveTilesOutsideBounds: 0
+    accuratePlacement: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -169,12 +167,10 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -199,7 +195,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &39507394
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -228,17 +223,9 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 39507391}
   m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
   m_IsTrigger: 0
-  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 5
+  serializedVersion: 4
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 0}
@@ -261,13 +248,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 39507391}
-  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 4, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &126862137
 GameObject:
@@ -297,17 +283,9 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 126862137}
   m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
   m_IsTrigger: 0
-  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 3
+  serializedVersion: 2
   m_Radius: 0.5
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &126862139
@@ -321,12 +299,10 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -351,7 +327,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &126862140
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -367,13 +342,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 126862137}
-  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 2, y: 0, z: 0}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &126862142
 MonoBehaviour:
@@ -416,13 +390,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 522487044}
-  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &522487046
 MeshFilter:
@@ -440,17 +413,9 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 522487044}
   m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
   m_IsTrigger: 0
-  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 5
+  serializedVersion: 4
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 0}
@@ -489,12 +454,10 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -519,7 +482,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &522487051
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -563,7 +525,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_SendPointerHoverToParent: 1
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -593,13 +554,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 727973698}
-  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &842730820
 GameObject:
@@ -642,17 +602,9 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
-  m_Iso: 200
-  m_ShutterSpeed: 0.005
-  m_Aperture: 16
-  m_FocusDistance: 10
-  m_FocalLength: 50
-  m_BladeCount: 5
-  m_Curvature: {x: 2, y: 11}
-  m_BarrelClipping: 0.25
-  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -686,13 +638,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 842730820}
-  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &842730824
 MonoBehaviour:
@@ -756,12 +707,10 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -786,7 +735,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &1005311020
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -815,17 +763,9 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1005311017}
   m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
   m_IsTrigger: 0
-  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 5
+  serializedVersion: 4
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 0}
@@ -848,13 +788,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1005311017}
-  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -2, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1389472667
 GameObject:
@@ -902,12 +841,10 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -932,7 +869,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &1389472670
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -961,17 +897,9 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1389472667}
   m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
   m_IsTrigger: 0
-  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 5
+  serializedVersion: 4
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 0}
@@ -994,13 +922,60 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1389472667}
-  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 2, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1448940718
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1448940720}
+  - component: {fileID: 1448940719}
+  m_Layer: 0
+  m_Name: Hint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1448940719
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448940718}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe4a094b2123f426dbd35f67018724cc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  activePointColor: {r: 0, g: 0, b: 1, a: 1}
+  inactivePointColor: {r: 1, g: 0, b: 0, a: 1}
+  originalPointColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  camera: {fileID: 842730822}
+  framesPerRefresh: 100
+--- !u!4 &1448940720
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448940718}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5.297858, y: 0.27795574, z: 0.12006394}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1487821872
 GameObject:
@@ -1078,7 +1053,6 @@ Light:
   m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
-  m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &1487821874
@@ -1088,23 +1062,10 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1487821872}
-  serializedVersion: 2
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 10, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1660057539 &9223372036854775807
-SceneRoots:
-  m_ObjectHideFlags: 0
-  m_Roots:
-  - {fileID: 842730823}
-  - {fileID: 1487821874}
-  - {fileID: 727973701}
-  - {fileID: 522487045}
-  - {fileID: 1389472674}
-  - {fileID: 126862141}
-  - {fileID: 39507398}
-  - {fileID: 1005311024}

--- a/Tests/Scenes/Hints.unity
+++ b/Tests/Scenes/Hints.unity
@@ -38,12 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028305, g: 0.22571313, b: 0.3069213, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481676, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 11
+  serializedVersion: 12
   m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -98,13 +98,13 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_LightingSettings: {fileID: 4890085278179872738, guid: c3f20b1f9a3b94a9c8857b67ced9e0d7, type: 2}
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
-    serializedVersion: 2
+    serializedVersion: 3
     agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
@@ -117,7 +117,9 @@ NavMeshSettings:
     cellSize: 0.16666667
     manualTileSize: 0
     tileSize: 256
-    accuratePlacement: 0
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -179,6 +181,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!223 &26146431
 Canvas:
   m_ObjectHideFlags: 0
@@ -196,7 +199,9 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -210,10 +215,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 376267673}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -249,9 +254,9 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 26146432}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
@@ -273,6 +278,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.392}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -365,6 +371,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!223 &515618580
 Canvas:
   m_ObjectHideFlags: 0
@@ -382,7 +389,9 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -396,10 +405,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1513493000}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -435,9 +444,9 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1870397215}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -459,6 +468,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.392}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -541,9 +551,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -577,12 +595,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 924120558}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -5}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &994452807
 GameObject:
@@ -614,6 +633,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -643,12 +663,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 994452807}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1201673380
 GameObject:
@@ -726,6 +747,7 @@ Light:
   m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &1201673382
@@ -735,12 +757,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1201673380}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!1 &1315248323
 GameObject:
@@ -771,8 +794,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe4a094b2123f426dbd35f67018724cc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  activePointColor: {r: 0, g: 0, b: 1, a: 1}
-  inactivePointColor: {r: 1, g: 0, b: 0, a: 1}
+  reachableColor: {r: 0, g: 0, b: 1, a: 1}
+  unreachableColor: {r: 0.9372549, g: 0.5058824, b: 0.05882353, a: 1}
   originalPointColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   framesPerRefresh: 100
 --- !u!4 &1315248325
@@ -782,12 +805,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1315248323}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.0000009536743, y: 0, z: -9.999999}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1356713968
 GameObject:
@@ -817,9 +841,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1356713968}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &1356713970
@@ -833,10 +865,12 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -861,6 +895,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &1356713971
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -876,12 +911,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1356713968}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -1, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1356713973
 MonoBehaviour:
@@ -924,9 +960,9 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 515618581}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -948,6 +984,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.392}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1011,9 +1048,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1554872514}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &1554872516
@@ -1027,10 +1072,12 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1055,6 +1102,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &1554872517
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -1070,12 +1118,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1554872514}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 1, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1554872519
 MonoBehaviour:
@@ -1160,6 +1209,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!223 &1870397214
 Canvas:
   m_ObjectHideFlags: 0
@@ -1177,7 +1227,9 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -1191,13 +1243,26 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 718548488}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 924120561}
+  - {fileID: 994452810}
+  - {fileID: 1554872518}
+  - {fileID: 1356713972}
+  - {fileID: 1201673382}
+  - {fileID: 1315248325}
+  - {fileID: 515618581}
+  - {fileID: 1870397215}
+  - {fileID: 26146432}

--- a/Tests/Scenes/Hints.unity
+++ b/Tests/Scenes/Hints.unity
@@ -1,0 +1,1203 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.18028305, g: 0.22571313, b: 0.3069213, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &26146428
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 26146432}
+  - component: {fileID: 26146431}
+  - component: {fileID: 26146430}
+  - component: {fileID: 26146429}
+  m_Layer: 5
+  m_Name: Canvas World Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &26146429
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26146428}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &26146430
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26146428}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &26146431
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26146428}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 924120560}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &26146432
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26146428}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 376267673}
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 3, y: 2}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &376267672
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 376267673}
+  - component: {fileID: 376267675}
+  - component: {fileID: 376267674}
+  - component: {fileID: 376267676}
+  m_Layer: 5
+  m_Name: Canvas World Camera Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &376267673
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 376267672}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 26146432}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &376267674
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 376267672}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &376267675
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 376267672}
+  m_CullTransparentMesh: 0
+--- !u!114 &376267676
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 376267672}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d451ee3d7a0c47a4a7111d005b3eed02, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &515618577
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 515618581}
+  - component: {fileID: 515618580}
+  - component: {fileID: 515618579}
+  - component: {fileID: 515618578}
+  m_Layer: 5
+  m_Name: Canvas Overlay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &515618578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 515618577}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &515618579
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 515618577}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &515618580
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 515618577}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &515618581
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 515618577}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 1513493000}
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &718548487
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 718548488}
+  - component: {fileID: 718548490}
+  - component: {fileID: 718548489}
+  - component: {fileID: 718548491}
+  m_Layer: 5
+  m_Name: Canvas Camera Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &718548488
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 718548487}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1870397215}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -50, y: -50}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &718548489
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 718548487}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &718548490
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 718548487}
+  m_CullTransparentMesh: 0
+--- !u!114 &718548491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 718548487}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d451ee3d7a0c47a4a7111d005b3eed02, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &924120558
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 924120561}
+  - component: {fileID: 924120560}
+  - component: {fileID: 924120559}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &924120559
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 924120558}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c49b4cc203aa6414fae5c798d1d0e7d6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EventMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_MaxRayIntersections: 0
+--- !u!20 &924120560
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 924120558}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &924120561
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 924120558}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &994452807
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 994452810}
+  - component: {fileID: 994452809}
+  - component: {fileID: 994452808}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &994452808
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 994452807}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &994452809
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 994452807}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &994452810
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 994452807}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1201673380
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1201673382}
+  - component: {fileID: 1201673381}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1201673381
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1201673380}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1201673382
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1201673380}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1315248323
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1315248325}
+  - component: {fileID: 1315248324}
+  m_Layer: 0
+  m_Name: Hint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1315248324
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1315248323}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe4a094b2123f426dbd35f67018724cc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  activePointColor: {r: 0, g: 0, b: 1, a: 1}
+  inactivePointColor: {r: 1, g: 0, b: 0, a: 1}
+  originalPointColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  framesPerRefresh: 100
+--- !u!4 &1315248325
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1315248323}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.0000009536743, y: 0, z: -9.999999}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1356713968
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1356713972}
+  - component: {fileID: 1356713971}
+  - component: {fileID: 1356713970}
+  - component: {fileID: 1356713969}
+  - component: {fileID: 1356713973}
+  m_Layer: 0
+  m_Name: Left Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1356713969
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356713968}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1356713970
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356713968}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1356713971
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356713968}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1356713972
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356713968}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1356713973
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356713968}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d451ee3d7a0c47a4a7111d005b3eed02, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1513492999
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1513493000}
+  - component: {fileID: 1513493002}
+  - component: {fileID: 1513493001}
+  - component: {fileID: 1513493003}
+  m_Layer: 5
+  m_Name: Canvas Overlay Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1513493000
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1513492999}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 515618581}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 50, y: -50}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1513493001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1513492999}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1513493002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1513492999}
+  m_CullTransparentMesh: 0
+--- !u!114 &1513493003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1513492999}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d451ee3d7a0c47a4a7111d005b3eed02, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1554872514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1554872518}
+  - component: {fileID: 1554872517}
+  - component: {fileID: 1554872516}
+  - component: {fileID: 1554872515}
+  - component: {fileID: 1554872519}
+  - component: {fileID: 1554872520}
+  m_Layer: 0
+  m_Name: Right Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1554872515
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1554872514}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1554872516
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1554872514}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1554872517
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1554872514}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1554872518
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1554872514}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1554872519
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1554872514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d451ee3d7a0c47a4a7111d005b3eed02, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1554872520
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1554872514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f99c0cd12f841dfa0f267ef90dc7cbe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  offset: {x: 1, y: 0, z: 0}
+--- !u!1 &1870397211
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1870397215}
+  - component: {fileID: 1870397214}
+  - component: {fileID: 1870397213}
+  - component: {fileID: 1870397212}
+  m_Layer: 5
+  m_Name: Canvas Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1870397212
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1870397211}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1870397213
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1870397211}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &1870397214
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1870397211}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 1
+  m_Camera: {fileID: 924120560}
+  m_PlaneDistance: 5
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1870397215
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1870397211}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 718548488}
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}

--- a/Tests/Scenes/Hints.unity.meta
+++ b/Tests/Scenes/Hints.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2a0702c9d5b5f4c9b87435983da0af25
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Scenes/HintsSettings.lighting
+++ b/Tests/Scenes/HintsSettings.lighting
@@ -1,0 +1,66 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!850595691 &4890085278179872738
+LightingSettings:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HintsSettings
+  serializedVersion: 6
+  m_GIWorkflowMode: 1
+  m_EnableBakedLightmaps: 0
+  m_EnableRealtimeLightmaps: 0
+  m_RealtimeEnvironmentLighting: 1
+  m_BounceScale: 1
+  m_AlbedoBoost: 1
+  m_IndirectOutputScale: 1
+  m_UsingShadowmask: 1
+  m_BakeBackend: 1
+  m_LightmapMaxSize: 1024
+  m_BakeResolution: 40
+  m_Padding: 2
+  m_LightmapCompression: 3
+  m_AO: 0
+  m_AOMaxDistance: 1
+  m_CompAOExponent: 1
+  m_CompAOExponentDirect: 0
+  m_ExtractAO: 0
+  m_MixedBakeMode: 2
+  m_LightmapsBakeMode: 1
+  m_FilterMode: 1
+  m_LightmapParameters: {fileID: 15204, guid: 0000000000000000f000000000000000, type: 0}
+  m_ExportTrainingData: 0
+  m_TrainingDataDestination: TrainingData
+  m_RealtimeResolution: 2
+  m_ForceWhiteAlbedo: 0
+  m_ForceUpdates: 0
+  m_FinalGather: 0
+  m_FinalGatherRayCount: 256
+  m_FinalGatherFiltering: 1
+  m_PVRCulling: 1
+  m_PVRSampling: 1
+  m_PVRDirectSampleCount: 32
+  m_PVRSampleCount: 512
+  m_PVREnvironmentSampleCount: 256
+  m_PVREnvironmentReferencePointCount: 2048
+  m_LightProbeSampleCountMultiplier: 4
+  m_PVRBounces: 2
+  m_PVRMinBounces: 2
+  m_PVREnvironmentImportanceSampling: 1
+  m_PVRFilteringMode: 1
+  m_PVRDenoiserTypeDirect: 1
+  m_PVRDenoiserTypeIndirect: 1
+  m_PVRDenoiserTypeAO: 1
+  m_PVRFilterTypeDirect: 0
+  m_PVRFilterTypeIndirect: 0
+  m_PVRFilterTypeAO: 0
+  m_PVRFilteringGaussRadiusDirect: 1
+  m_PVRFilteringGaussRadiusIndirect: 5
+  m_PVRFilteringGaussRadiusAO: 2
+  m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+  m_PVRFilteringAtrousPositionSigmaIndirect: 2
+  m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_PVRTiledBaking: 0
+  m_NumRaysToShootPerTexel: -1
+  m_RespectSceneVisibilityWhenBakingGI: 0

--- a/Tests/Scenes/HintsSettings.lighting.meta
+++ b/Tests/Scenes/HintsSettings.lighting.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3f20b1f9a3b94a9c8857b67ced9e0d7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 4890085278179872738
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I implemented hints for interactive components on SceneView and GameView. Related #45.

### Screenshot

#### Perspective
![](https://github.com/nowsprinting/test-helper.monkey/assets/1124024/fb21e842-e667-4b75-b555-1fd76d0f2909)

#### Orthographic
![](https://github.com/nowsprinting/test-helper.monkey/assets/1124024/5f35ef83-6e6b-4984-979b-470e735cee0b)

### Limitations
![](https://github.com/nowsprinting/test-helper.monkey/assets/1124024/d62a0bc6-ecad-4723-928f-d62907bef03d)

Hints for components on canvas that has screen space overlay as the render mode are not rendered on GameView. There are on only SceneView.