### PR TITLE
Add "Editor" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "Annotations*",
     "Documentation~",
     "Runtime*",
+    "Editor*",
     "Tests*",
     "LICENSE.md*",
     "package.json*",


### PR DESCRIPTION
In my project, the Editor directory got missing when I installed test-helper.monkey via Git URL.

I suspect this cause is "files" in package.json.