### PR TITLE
Make Do not run tests on public fork

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ concurrency:
 
 jobs:
   test:
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Because of Unity authentication error.