### PR TITLE
Add command line argument to specify screenshot save directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}  # Default is `auto`
           checkName: test result (${{ matrix.unityVersion }})
           projectPath: ${{ env.CREATED_PROJECT_PATH }}
-          customParameters: -testCategory "!IgnoreCI" -testHelperScreenshotDirectory ${{ env.CREATED_PROJECT_PATH }}/Logs/Screenshots
+          customParameters: -testCategory "!IgnoreCI" -testHelperScreenshotDirectory /github/workspace/artifacts/Screenshots
           coverageOptions: generateAdditionalMetrics;generateTestReferences;generateHtmlReport;generateAdditionalReports;dontClear;assemblyFilters:${{ env.assembly_filters }}
           # see: https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html
         env:
@@ -114,7 +114,6 @@ jobs:
           path: |
             ${{ steps.test.outputs.artifactsPath }}
             ${{ steps.test.outputs.coveragePath }}
-            ${{ env.CREATED_PROJECT_PATH }}/Logs/Screenshots
         if: always()
 
   notify:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}  # Default is `auto`
           checkName: test result (${{ matrix.unityVersion }})
           projectPath: ${{ env.CREATED_PROJECT_PATH }}
-          customParameters: -testCategory "!IgnoreCI"
+          customParameters: -testCategory "!IgnoreCI" -testHelperScreenshotDirectory ${{ env.CREATED_PROJECT_PATH }}/Logs/Screenshots
           coverageOptions: generateAdditionalMetrics;generateTestReferences;generateHtmlReport;generateAdditionalReports;dontClear;assemblyFilters:${{ env.assembly_filters }}
           # see: https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html
         env:
@@ -114,6 +114,7 @@ jobs:
           path: |
             ${{ steps.test.outputs.artifactsPath }}
             ${{ steps.test.outputs.coveragePath }}
+            ${{ env.CREATED_PROJECT_PATH }}/Logs/Screenshots
         if: always()
 
   notify:

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ $(TEST_CATEGORY) \
 $(TEST_FILTER) \
 $(ASSEMBLY_NAMES) \
 -testPlatform $(TEST_PLATFORM) \
--testResults $(LOG_DIR)/test_$(TEST_PLATFORM)_results.xml
+-testResults $(LOG_DIR)/test_$(TEST_PLATFORM)_results.xml \
+-testHelperScreenshotDirectory $(LOG_DIR)/Screenshots
 endef
 
 define test

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Configurations in `MonkeyConfig`:
 
 Configurations in `ScreenshotOptions`:
 
-- **Directory**: Directory path to save screenshots. Default save path is `Application.persistentDataPath` + "/TestHelper.Monkey/Screenshots/".
+- **Directory**: Directory to save screenshots. If omitted, the directory specified by command line argument "-testHelperScreenshotDirectory" is used. If the command line argument is also omitted, `Application.persistentDataPath` + "/TestHelper/Screenshots/" is used.
 - **FilenameStrategy**: Strategy for file paths of screenshot images. Default is test case name and four digit sequential number.
 - **SuperSize**: The factor to increase resolution with. Default is 1.
 - **StereoCaptureMode**: The eye texture to capture when stereo rendering is enabled. Default is `LeftEye`.

--- a/Runtime/ScreenshotOptions.cs
+++ b/Runtime/ScreenshotOptions.cs
@@ -1,8 +1,8 @@
-// Copyright (c) 2023 Koji Hasegawa.
+// Copyright (c) 2023-2024 Koji Hasegawa.
 // This software is released under the MIT License.
 
-using System.IO;
 using TestHelper.Monkey.ScreenshotFilenameStrategies;
+using TestHelper.RuntimeInternals;
 using UnityEngine;
 
 namespace TestHelper.Monkey
@@ -13,11 +13,12 @@ namespace TestHelper.Monkey
     public class ScreenshotOptions
     {
         /// <summary>
-        /// Directory path to save screenshots.
-        /// Default save path is <c>Application.persistentDataPath</c> + "/TestHelper.Monkey/Screenshots/".
+        /// Directory to save screenshots.
+        /// If omitted, the directory specified by command line argument "-testHelperScreenshotDirectory" is used.
+        /// If the command line argument is also omitted, <c>Application.persistentDataPath</c> + "/TestHelper/Screenshots/" is used.
         /// </summary>
-        public string Directory { get; set; } = GetDefaultDirectory();
-        
+        public string Directory { get; set; } = CommandLineArgs.GetScreenshotDirectory();
+
         /// <summary>
         /// Strategy for file paths of screenshot images.
         /// </summary>
@@ -39,15 +40,5 @@ namespace TestHelper.Monkey
         /// </remarks>
         public ScreenCapture.StereoScreenCaptureMode StereoCaptureMode { get; set; } =
             ScreenCapture.StereoScreenCaptureMode.LeftEye;
-        
-
-        /// <summary>
-        /// Returns a default directory for screenshot images
-        /// </summary>
-        /// <returns>Default directory for screenshot images</returns>
-        private static string GetDefaultDirectory()
-        {
-            return Path.Combine(Application.persistentDataPath, "TestHelper.Monkey", "Screenshots");
-        }
     }
 }

--- a/Tests/Runtime/MonkeyTest.cs
+++ b/Tests/Runtime/MonkeyTest.cs
@@ -344,13 +344,14 @@ namespace TestHelper.Monkey
         {
             private const int FileSizeThreshold = 5441; // VGA size solid color file size
             private const int FileSizeThreshold2X = 100 * 1024; // Normal size is 80 to 90KB
+            private readonly string _defaultOutputDirectory = CommandLineArgs.GetScreenshotDirectory();
 
             [Test]
             [LoadScene(TestScene)]
             public async Task Run_withScreenshots_takeScreenshotsAndSaveToDefaultPath()
             {
-                var directory = Path.Combine(Application.persistentDataPath, "TestHelper.Monkey", "Screenshots");
-                var path = Path.Combine(directory, $"{nameof(Run_withScreenshots_takeScreenshotsAndSaveToDefaultPath)}_0001.png");
+                var filename = $"{nameof(Run_withScreenshots_takeScreenshotsAndSaveToDefaultPath)}_0001.png";
+                var path = Path.Combine(_defaultOutputDirectory, filename);
                 if (File.Exists(path))
                 {
                     File.Delete(path);
@@ -409,9 +410,8 @@ namespace TestHelper.Monkey
             [LoadScene(TestScene)]
             public async Task Run_withScreenshots_superSize_takeScreenshotsSuperSize()
             {
-                var directory = Path.Combine(Application.persistentDataPath, "TestHelper.Monkey", "Screenshots");
                 var filename = $"{nameof(Run_withScreenshots_superSize_takeScreenshotsSuperSize)}_0001.png";
-                var path = Path.Combine(directory, filename);
+                var path = Path.Combine(_defaultOutputDirectory, filename);
                 if (File.Exists(path))
                 {
                     File.Delete(path);
@@ -442,9 +442,8 @@ namespace TestHelper.Monkey
             [Description("Is it a stereo screenshot? See for yourself! Be a witness!!")]
             public async Task Run_withScreenshots_stereo_takeScreenshotsStereo()
             {
-                var directory = Path.Combine(Application.persistentDataPath, "TestHelper.Monkey", "Screenshots");
                 var filename = $"{nameof(Run_withScreenshots_stereo_takeScreenshotsStereo)}_0001.png";
-                var path = Path.Combine(directory, filename);
+                var path = Path.Combine(_defaultOutputDirectory, filename);
                 if (File.Exists(path))
                 {
                     File.Delete(path);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "changelogUrl": "https://github.com/nowsprinting/test-helper.monkey/releases",
   "dependencies": {
     "com.cysharp.unitask": "2.3.3",
-    "com.nowsprinting.test-helper": "0.4.2",
+    "com.nowsprinting.test-helper": "0.5.0",
     "com.nowsprinting.test-helper.random": "0.3.0",
     "com.unity.ugui": "1.0.0"
   },


### PR DESCRIPTION
Changed the default screenshot save directory.
This feature is inherited from test-helper v0.5. see: https://github.com/nowsprinting/test-helper/pull/63

### Before:
Application.persistentDataPath+/TestHelper.Monkey/Screenshots

### After:
First, command line argument "-testHelperScreenshotDirectory".
If the command line argument is omitted, <c>Application.persistentDataPath</c> + "/TestHelper/Screenshots/" is used. (removed `.Monkey`)