### PR TITLE
Refactor InteractiveComponent

### DIFF
--- a/Runtime/GameObjectFinder.cs
+++ b/Runtime/GameObjectFinder.cs
@@ -73,7 +73,7 @@ namespace TestHelper.Monkey
 
             if (reachable)
             {
-                _eventData.position = _getScreenPoint(foundObject);
+                _eventData.position = _getScreenPoint.Invoke(foundObject);
                 if (!_isReachable.Invoke(foundObject, _eventData, _results))
                 {
                     return (null, Reason.NotReachable);

--- a/Runtime/Hints/InteractiveComponentHint.cs
+++ b/Runtime/Hints/InteractiveComponentHint.cs
@@ -15,7 +15,7 @@ namespace TestHelper.Monkey.Hints
     public class InteractiveComponentHint : MonoBehaviour
     {
         private static readonly Color s_orange = new Color(0xef, 0x81, 0x0f);
-        
+
         /// <summary>
         /// Color for interactive components that users can operate
         /// </summary>
@@ -100,7 +100,7 @@ namespace TestHelper.Monkey.Hints
 
             foreach (var component in InteractiveComponentCollector.FindInteractableComponents())
             {
-                var dst = component.IsReallyInteractiveFromUser(GetScreenPoint)
+                var dst = component.IsReachable()
                     ? _tmpReallyInteractives
                     : _tmpNotReallyInteractives;
 

--- a/Runtime/Hints/InteractiveComponentHint.cs
+++ b/Runtime/Hints/InteractiveComponentHint.cs
@@ -98,7 +98,8 @@ namespace TestHelper.Monkey.Hints
         {
             Clear();
 
-            foreach (var component in InteractiveComponentCollector.FindInteractableComponents())
+            var interactiveComponentCollector = new InteractiveComponentCollector(getScreenPoint: GetScreenPoint);
+            foreach (var component in interactiveComponentCollector.FindInteractableComponents())
             {
                 var dst = component.IsReachable()
                     ? _tmpReallyInteractives

--- a/Runtime/InteractiveComponent.cs
+++ b/Runtime/InteractiveComponent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Koji Hasegawa.
+﻿// Copyright (c) 2023-2024 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -10,6 +10,7 @@ using TestHelper.Monkey.DefaultStrategies;
 using TestHelper.Monkey.Extensions;
 using TestHelper.Monkey.Operators;
 using TestHelper.Monkey.Random;
+using TestHelper.Monkey.ScreenPointStrategies;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -39,32 +40,55 @@ namespace TestHelper.Monkey
         [SuppressMessage("ReSharper", "InconsistentNaming")]
         public GameObject gameObject => component.gameObject;
 
+        private readonly Func<GameObject, Vector2> _getScreenPoint;
+        private readonly Func<GameObject, PointerEventData, List<RaycastResult>, bool> _isReachable;
+        private readonly PointerEventData _eventData = new PointerEventData(EventSystem.current);
+        private readonly List<RaycastResult> _results = new List<RaycastResult>();
+
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="component"></param>
-        public InteractiveComponent(MonoBehaviour component)
+        /// <param name="getScreenPoint">The function returns the screen position where raycast for the found <c>GameObject</c>.
+        /// Default is <c>DefaultScreenPointStrategy.GetScreenPoint</c>.</param>
+        /// <param name="isReachable">The function returns the <c>GameObject</c> is reachable from user or not.
+        /// Default is <c>DefaultReachableStrategy.IsReachable</c>.</param>
+        public InteractiveComponent(MonoBehaviour component,
+            Func<GameObject, Vector2> getScreenPoint = null,
+            Func<GameObject, PointerEventData, List<RaycastResult>, bool> isReachable = null)
         {
             this.component = component;
+            _getScreenPoint = getScreenPoint ?? DefaultScreenPointStrategy.GetScreenPoint;
+            _isReachable = isReachable ?? DefaultReachableStrategy.IsReachable;
         }
 
         /// <summary>
         /// Create <c>InteractableComponent</c> instance from GameObject.
         /// </summary>
         /// <param name="gameObject"></param>
-        /// <param name="isInteractable">The function returns the <c>Component</c> is interactable or not.
+        /// <param name="getScreenPoint">The function returns the screen position where raycast for the found <c>GameObject</c>.
+        /// Default is <c>DefaultScreenPointStrategy.GetScreenPoint</c>.</param>
+        /// <param name="isComponentInteractable">The function returns the <c>Component</c> is interactable or not.
         /// Default is <c>DefaultComponentInteractableStrategy.IsInteractable</c>.</param>
+        /// <param name="isReachable">The function returns the <c>GameObject</c> is reachable from user or not.
+        /// Default is <c>DefaultReachableStrategy.IsReachable</c>.</param>
         /// <returns>Returns new InteractableComponent instance from GameObject. If GameObject is not interactable so, return null.</returns>
         public static InteractiveComponent CreateInteractableComponent(GameObject gameObject,
-            Func<Component, bool> isInteractable = null)
+            Func<GameObject, Vector2> getScreenPoint = null,
+            Func<Component, bool> isComponentInteractable = null,
+            Func<GameObject, PointerEventData, List<RaycastResult>, bool> isReachable = null)
         {
-            isInteractable = isInteractable ?? DefaultComponentInteractableStrategy.IsInteractable;
+            getScreenPoint = getScreenPoint ?? DefaultScreenPointStrategy.GetScreenPoint;
+            isComponentInteractable = isComponentInteractable ?? DefaultComponentInteractableStrategy.IsInteractable;
+            isReachable = isReachable ?? DefaultReachableStrategy.IsReachable;
 
             foreach (var component in gameObject.GetComponents<MonoBehaviour>())
             {
-                if (isInteractable(component))
+                if (isComponentInteractable.Invoke(component))
                 {
-                    return new InteractiveComponent(component);
+                    return new InteractiveComponent(component,
+                        getScreenPoint,
+                        isReachable);
                 }
             }
 
@@ -78,11 +102,21 @@ namespace TestHelper.Monkey
         /// <param name="eventData">Specify if avoid GC memory allocation</param>
         /// <param name="results">Specify if avoid GC memory allocation</param>
         /// <returns>true: this object can control by user</returns>
-        [Obsolete("Use GameObjectExtensions.IsReachable() instead")]
+        [Obsolete("Use IsReachable() instead")]
         public bool IsReallyInteractiveFromUser(Func<GameObject, Vector2> screenPointStrategy,
             PointerEventData eventData = null, List<RaycastResult> results = null)
         {
             return gameObject.IsReachable(screenPointStrategy, eventData, results);
+        }
+
+        /// <summary>
+        /// Hit test using raycaster
+        /// </summary>
+        /// <returns>true: this object can control by user</returns>
+        public bool IsReachable()
+        {
+            _eventData.position = _getScreenPoint.Invoke(gameObject);
+            return _isReachable.Invoke(gameObject, _eventData, _results);
         }
 
         /// <summary>

--- a/Runtime/InteractiveComponent.cs
+++ b/Runtime/InteractiveComponent.cs
@@ -128,9 +128,7 @@ namespace TestHelper.Monkey
         /// <summary>
         /// Click inner component
         /// </summary>
-        /// <param name="screenPointStrategy">Function returns the screen position where monkey operators operate on for the specified gameObject</param>
-        public void Click(Func<GameObject, Vector2> screenPointStrategy = null) =>
-            ClickOperator.Click(component, screenPointStrategy);
+        public void Click() => ClickOperator.Click(component, _getScreenPoint);
 
         /// <summary>
         /// Check inner component can receive tap (click) event
@@ -141,9 +139,7 @@ namespace TestHelper.Monkey
         /// <summary>
         /// Tap (click) inner component
         /// </summary>
-        /// <param name="screenPointStrategy">Function returns the screen position where monkey operators operate on for the specified gameObject</param>
-        public void Tap(Func<GameObject, Vector2> screenPointStrategy = null) =>
-            ClickOperator.Click(component, screenPointStrategy);
+        public void Tap() => ClickOperator.Click(component, _getScreenPoint);
 
         /// <summary>
         /// Check inner component can receive touch-and-hold event
@@ -157,9 +153,8 @@ namespace TestHelper.Monkey
         /// <param name="screenPointStrategy">Function returns the screen position where monkey operators operate on for the specified gameObject</param>
         /// <param name="delayMillis">Delay time between down to up</param>
         /// <param name="cancellationToken">Task cancellation token</param>
-        public async UniTask TouchAndHold(Func<GameObject, Vector2> screenPointStrategy = null, int delayMillis = 1000,
-            CancellationToken cancellationToken = default)
-            => await TouchAndHoldOperator.TouchAndHold(component, screenPointStrategy, delayMillis, cancellationToken);
+        public async UniTask TouchAndHold(int delayMillis = 1000, CancellationToken cancellationToken = default)
+            => await TouchAndHoldOperator.TouchAndHold(component, _getScreenPoint, delayMillis, cancellationToken);
 
         /// <summary>
         /// Check inner component can input text

--- a/Runtime/Monkey.cs
+++ b/Runtime/Monkey.cs
@@ -175,11 +175,10 @@ namespace TestHelper.Monkey
             switch (operation)
             {
                 case SupportOperation.Click:
-                    component.Click(config.ScreenPointStrategy);
+                    component.Click();
                     break;
                 case SupportOperation.TouchAndHold:
                     await component.TouchAndHold(
-                        config.ScreenPointStrategy,
                         config.TouchAndHoldDelayMillis,
                         cancellationToken
                     );

--- a/Tests/Runtime/Annotations/PositionAnnotationTest.cs
+++ b/Tests/Runtime/Annotations/PositionAnnotationTest.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using NUnit.Framework;
 using TestHelper.Attributes;
-using TestHelper.Monkey.ScreenPointStrategies;
 
 namespace TestHelper.Monkey.Annotations
 {
@@ -32,7 +31,7 @@ namespace TestHelper.Monkey.Annotations
             // Without no position annotations, IsReallyInteractiveFromUser() is always false because
             // gameObject.transform.position is not in the mesh. So IsReallyInteractiveFromUser() is true means
             // the position annotation work well
-            Assert.That(target.IsReallyInteractiveFromUser(DefaultScreenPointStrategy.GetScreenPoint), Is.True);
+            Assert.That(target.IsReachable(), Is.True);
         }
     }
 }

--- a/Tests/Runtime/Annotations/PositionAnnotationTest.cs
+++ b/Tests/Runtime/Annotations/PositionAnnotationTest.cs
@@ -24,7 +24,7 @@ namespace TestHelper.Monkey.Annotations
             string name
         )
         {
-            var target = InteractiveComponentCollector
+            var target = new InteractiveComponentCollector()
                 .FindInteractableComponents()
                 .First(x => x.gameObject.name == name);
 

--- a/Tests/Runtime/InteractiveComponentCollectorTest.cs
+++ b/Tests/Runtime/InteractiveComponentCollectorTest.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
-using TestHelper.Monkey.ScreenPointStrategies;
 
 namespace TestHelper.Monkey
 {
@@ -44,7 +43,7 @@ namespace TestHelper.Monkey
             [LoadScene(TestScene)]
             public void FindInteractiveObjects_findAllInteractiveObjects()
             {
-                var actual = InteractiveComponentCollector.FindInteractableComponents()
+                var actual = new InteractiveComponentCollector().FindInteractableComponents()
                     .Select(x => x.gameObject.name)
                     .ToArray();
                 Assert.That(actual, Is.EquivalentTo(s_interactiveObjects()));
@@ -54,8 +53,7 @@ namespace TestHelper.Monkey
             [LoadScene(TestScene)]
             public void FindInteractiveObjects_reallyInteractiveOnly_findReachableObjects()
             {
-                var actual = InteractiveComponentCollector
-                    .FindReachableInteractableComponents(DefaultScreenPointStrategy.GetScreenPoint)
+                var actual = new InteractiveComponentCollector().FindReachableInteractableComponents()
                     .Select(x => x.gameObject.name)
                     .ToArray();
                 Assert.That(actual, Is.EquivalentTo(s_reachableObjects));
@@ -93,7 +91,7 @@ namespace TestHelper.Monkey
             [LoadScene(TestScene)]
             public void FindInteractiveObjects_findAllInteractiveObjects()
             {
-                var actual = InteractiveComponentCollector.FindInteractableComponents()
+                var actual = new InteractiveComponentCollector().FindInteractableComponents()
                     .Select(x => x.gameObject.name)
                     .ToArray();
                 Assert.That(actual, Is.EquivalentTo(s_interactiveObjects()));
@@ -105,8 +103,7 @@ namespace TestHelper.Monkey
             {
                 await Task.Yield(); // wait for GraphicRaycaster initialization
 
-                var actual = InteractiveComponentCollector
-                    .FindReachableInteractableComponents(DefaultScreenPointStrategy.GetScreenPoint)
+                var actual = new InteractiveComponentCollector().FindReachableInteractableComponents()
                     .Select(x => x.gameObject.name)
                     .ToArray();
                 Assert.That(actual, Is.EquivalentTo(s_reachableObjects));
@@ -160,7 +157,7 @@ namespace TestHelper.Monkey
                 [LoadScene(TestScene)]
                 public void FindInteractiveObjects_findAllInteractiveObjects()
                 {
-                    var actual = InteractiveComponentCollector.FindInteractableComponents()
+                    var actual = new InteractiveComponentCollector().FindInteractableComponents()
                         .Select(x => x.gameObject.name)
                         .ToArray();
                     Assert.That(actual, Is.EquivalentTo(s_interactiveUiObjectsInOverlayCanvas()));
@@ -172,8 +169,7 @@ namespace TestHelper.Monkey
                 {
                     await Task.Yield(); // wait for GraphicRaycaster initialization
 
-                    var actual = InteractiveComponentCollector
-                        .FindReachableInteractableComponents(DefaultScreenPointStrategy.GetScreenPoint)
+                    var actual = new InteractiveComponentCollector().FindReachableInteractableComponents()
                         .Select(x => x.gameObject.name)
                         .ToArray();
                     Assert.That(actual, Is.EquivalentTo(s_reachableUiObjects));
@@ -193,7 +189,7 @@ namespace TestHelper.Monkey
                 [LoadScene(TestScene)]
                 public void FindInteractiveObjects_findAllInteractiveObjects()
                 {
-                    var actual = InteractiveComponentCollector.FindInteractableComponents()
+                    var actual = new InteractiveComponentCollector().FindInteractableComponents()
                         .Select(x => x.gameObject.name)
                         .ToArray();
                     Assert.That(actual, Is.EquivalentTo(s_interactiveUiObjects()));
@@ -205,8 +201,7 @@ namespace TestHelper.Monkey
                 {
                     await Task.Yield(); // wait for GraphicRaycaster initialization
 
-                    var actual = InteractiveComponentCollector
-                        .FindReachableInteractableComponents(DefaultScreenPointStrategy.GetScreenPoint)
+                    var actual = new InteractiveComponentCollector().FindReachableInteractableComponents()
                         .Select(x => x.gameObject.name)
                         .ToArray();
                     Assert.That(actual, Is.EquivalentTo(s_reachableUiObjects));
@@ -226,7 +221,7 @@ namespace TestHelper.Monkey
                 [LoadScene(TestScene)]
                 public void FindInteractiveObjects_findAllInteractiveObjects()
                 {
-                    var actual = InteractiveComponentCollector.FindInteractableComponents()
+                    var actual = new InteractiveComponentCollector().FindInteractableComponents()
                         .Select(x => x.gameObject.name)
                         .ToArray();
                     Assert.That(actual, Is.EquivalentTo(s_interactiveUiObjects()));
@@ -238,8 +233,7 @@ namespace TestHelper.Monkey
                 {
                     await Task.Yield(); // wait for GraphicRaycaster initialization
 
-                    var actual = InteractiveComponentCollector
-                        .FindReachableInteractableComponents(DefaultScreenPointStrategy.GetScreenPoint)
+                    var actual = new InteractiveComponentCollector().FindReachableInteractableComponents()
                         .Select(x => x.gameObject.name)
                         .ToArray();
                     Assert.That(actual, Is.EquivalentTo(s_reachableUiObjects));

--- a/Tests/Runtime/InteractiveComponentTest.cs
+++ b/Tests/Runtime/InteractiveComponentTest.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
-using TestHelper.Monkey.ScreenPointStrategies;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.TestTools;
@@ -125,7 +124,7 @@ namespace TestHelper.Monkey
                     .First(x => x.gameObject.name == targetName);
 
                 Assert.That(target.CanTap(), Is.True);
-                target.Tap(DefaultScreenPointStrategy.GetScreenPoint);
+                target.Tap();
 
                 LogAssert.Expect(LogType.Log, $"{targetName}.{expectedMessage}");
             }

--- a/Tests/Runtime/InteractiveComponentTest.cs
+++ b/Tests/Runtime/InteractiveComponentTest.cs
@@ -61,7 +61,7 @@ namespace TestHelper.Monkey
             [LoadScene(TestScene)]
             public void IsReallyInteractiveFromUser_reachableObjects_returnTrue(string targetName)
             {
-                var target = InteractiveComponentCollector.FindInteractableComponents()
+                var target = new InteractiveComponentCollector().FindInteractableComponents()
                     .First(x => x.gameObject.name == targetName);
 
                 Assert.That(target.IsReachable(), Is.True);
@@ -72,7 +72,7 @@ namespace TestHelper.Monkey
             [LoadScene(TestScene)]
             public void IsReallyInteractiveFromUser_unreachableObjects_returnFalse(string targetName)
             {
-                var target = InteractiveComponentCollector.FindInteractableComponents()
+                var target = new InteractiveComponentCollector().FindInteractableComponents()
                     .First(x => x.gameObject.name == targetName);
 
                 Assert.That(target.IsReachable(), Is.False);
@@ -96,7 +96,7 @@ namespace TestHelper.Monkey
             {
                 await Task.Yield(); // wait for GraphicRaycaster initialization
 
-                var target = InteractiveComponentCollector.FindInteractableComponents()
+                var target = new InteractiveComponentCollector().FindInteractableComponents()
                     .First(x => x.gameObject.name == targetName);
 
                 Assert.That(target.IsReachable(), Is.True);
@@ -111,7 +111,7 @@ namespace TestHelper.Monkey
             {
                 await Task.Yield(); // wait for GraphicRaycaster initialization
 
-                var target = InteractiveComponentCollector.FindInteractableComponents()
+                var target = new InteractiveComponentCollector().FindInteractableComponents()
                     .First(x => x.gameObject.name == targetName);
 
                 Assert.That(target.IsReachable(), Is.False);
@@ -121,7 +121,7 @@ namespace TestHelper.Monkey
             [LoadScene(TestScene)]
             public void Tap_Tapped(string targetName, string expectedMessage)
             {
-                var target = InteractiveComponentCollector.FindInteractableComponents()
+                var target = new InteractiveComponentCollector().FindInteractableComponents()
                     .First(x => x.gameObject.name == targetName);
 
                 Assert.That(target.CanTap(), Is.True);

--- a/Tests/Runtime/InteractiveComponentTest.cs
+++ b/Tests/Runtime/InteractiveComponentTest.cs
@@ -64,7 +64,7 @@ namespace TestHelper.Monkey
                 var target = InteractiveComponentCollector.FindInteractableComponents()
                     .First(x => x.gameObject.name == targetName);
 
-                Assert.That(target.IsReallyInteractiveFromUser(DefaultScreenPointStrategy.GetScreenPoint), Is.True);
+                Assert.That(target.IsReachable(), Is.True);
             }
 
             [TestCase("BeyondTheWall")] // Beyond the another object
@@ -75,7 +75,7 @@ namespace TestHelper.Monkey
                 var target = InteractiveComponentCollector.FindInteractableComponents()
                     .First(x => x.gameObject.name == targetName);
 
-                Assert.That(target.IsReallyInteractiveFromUser(DefaultScreenPointStrategy.GetScreenPoint), Is.False);
+                Assert.That(target.IsReachable(), Is.False);
             }
         }
 
@@ -99,7 +99,7 @@ namespace TestHelper.Monkey
                 var target = InteractiveComponentCollector.FindInteractableComponents()
                     .First(x => x.gameObject.name == targetName);
 
-                Assert.That(target.IsReallyInteractiveFromUser(DefaultScreenPointStrategy.GetScreenPoint), Is.True);
+                Assert.That(target.IsReachable(), Is.True);
             }
 
             [TestCase("BeyondTheWall")] // Beyond the another object
@@ -114,7 +114,7 @@ namespace TestHelper.Monkey
                 var target = InteractiveComponentCollector.FindInteractableComponents()
                     .First(x => x.gameObject.name == targetName);
 
-                Assert.That(target.IsReallyInteractiveFromUser(DefaultScreenPointStrategy.GetScreenPoint), Is.False);
+                Assert.That(target.IsReachable(), Is.False);
             }
 
             [TestCase("Button", "ReceiveOnClick")]

--- a/Tests/Runtime/MonkeyTest.cs
+++ b/Tests/Runtime/MonkeyTest.cs
@@ -12,7 +12,6 @@ using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
 using TestHelper.Monkey.Annotations;
-using TestHelper.Monkey.ScreenPointStrategies;
 using TestHelper.Monkey.TestDoubles;
 using TestHelper.Random;
 using TestHelper.RuntimeInternals;
@@ -36,7 +35,7 @@ namespace TestHelper.Monkey
                 TouchAndHoldDelayMillis = 1, // 1ms
             };
 
-            var didAct = await Monkey.RunStep(config);
+            var didAct = await Monkey.RunStep(config, new InteractiveComponentCollector());
             Assert.That(didAct, Is.EqualTo(true));
         }
 
@@ -44,7 +43,8 @@ namespace TestHelper.Monkey
         [LoadScene(TestScene)]
         public async Task RunStep_noInteractiveComponent_abort()
         {
-            foreach (var component in InteractiveComponentCollector.FindInteractableComponents())
+            var interactiveComponentCollector = new InteractiveComponentCollector();
+            foreach (var component in interactiveComponentCollector.FindInteractableComponents())
             {
                 component.gameObject.SetActive(false);
             }
@@ -55,7 +55,7 @@ namespace TestHelper.Monkey
                 TouchAndHoldDelayMillis = 1, // 1ms
             };
 
-            var didAct = await Monkey.RunStep(config);
+            var didAct = await Monkey.RunStep(config, interactiveComponentCollector);
             Assert.That(didAct, Is.EqualTo(false));
         }
 
@@ -99,7 +99,8 @@ namespace TestHelper.Monkey
         [LoadScene(TestScene)]
         public async Task Run_noInteractiveComponent_abort()
         {
-            foreach (var component in InteractiveComponentCollector.FindInteractableComponents())
+            var interactiveComponentCollector = new InteractiveComponentCollector();
+            foreach (var component in interactiveComponentCollector.FindInteractableComponents())
             {
                 component.gameObject.SetActive(false);
             }
@@ -125,7 +126,8 @@ namespace TestHelper.Monkey
         [LoadScene(TestScene)]
         public async Task Run_noInteractiveComponentAndSecondsToErrorForNoInteractiveComponentIsZero_finish()
         {
-            foreach (var component in InteractiveComponentCollector.FindInteractableComponents())
+            var interactiveComponentCollector = new InteractiveComponentCollector();
+            foreach (var component in interactiveComponentCollector.FindInteractableComponents())
             {
                 component.gameObject.SetActive(false);
             }
@@ -186,13 +188,13 @@ namespace TestHelper.Monkey
         [LoadScene(TestScene)]
         public void Lottery_hitInteractiveComponent_returnComponent()
         {
-            var components = InteractiveComponentCollector
-                .FindReachableInteractableComponents(DefaultScreenPointStrategy.GetScreenPoint).ToList();
+            var interactiveComponentCollector = new InteractiveComponentCollector();
+            var components = interactiveComponentCollector.FindReachableInteractableComponents().ToList();
             for (var i = 0; i < components.Count; i++)
             {
                 var random = new StubRandom(i);
                 var expected = components[i];
-                var actual = Monkey.Lottery(ref components, random, DefaultScreenPointStrategy.GetScreenPoint);
+                var actual = Monkey.Lottery(ref components, random);
 
                 Assert.That(actual.gameObject.name, Is.EqualTo(expected.gameObject.name));
             }
@@ -217,7 +219,7 @@ namespace TestHelper.Monkey
 
             var random = new StubRandom(0, 1);
             var expected = components[2];
-            var actual = Monkey.Lottery(ref components, random, DefaultScreenPointStrategy.GetScreenPoint);
+            var actual = Monkey.Lottery(ref components, random);
 
             Assert.That(actual.gameObject.name, Is.EqualTo(expected.gameObject.name));
             Assert.That(components, Has.Count.EqualTo(3)); // Removed not interactive objects.
@@ -235,7 +237,7 @@ namespace TestHelper.Monkey
             components[0].gameObject.SetActive(false);
 
             var random = new StubRandom(0);
-            var actual = Monkey.Lottery(ref components, random, DefaultScreenPointStrategy.GetScreenPoint);
+            var actual = Monkey.Lottery(ref components, random);
 
             Assert.That(actual, Is.Null);
             Assert.That(components, Has.Count.EqualTo(0)); // Removed not interactive objects.
@@ -253,7 +255,7 @@ namespace TestHelper.Monkey
             components[0].gameObject.AddComponent<IgnoreAnnotation>();
 
             var random = new StubRandom(0);
-            var actual = Monkey.Lottery(ref components, random, DefaultScreenPointStrategy.GetScreenPoint);
+            var actual = Monkey.Lottery(ref components, random);
 
             Assert.That(actual, Is.Null);
             Assert.That(components, Has.Count.EqualTo(0)); // Removed not interactive objects.
@@ -273,7 +275,7 @@ namespace TestHelper.Monkey
         [LoadScene(TestScene)]
         public async Task DoOperation_invokeOperationByLottery(string target, int index, string operation)
         {
-            var component = InteractiveComponentCollector.FindInteractableComponents()
+            var component = new InteractiveComponentCollector().FindInteractableComponents()
                 .First(x => x.gameObject.name == target);
             var spyLogger = new SpyLogger();
             var config = new MonkeyConfig
@@ -296,7 +298,7 @@ namespace TestHelper.Monkey
             const int Index = 0;
             const string Operation = "TouchAndHold";
 
-            var component = InteractiveComponentCollector.FindInteractableComponents()
+            var component = new InteractiveComponentCollector().FindInteractableComponents()
                 .First(x => x.gameObject.name == Target);
             var spyLogger = new SpyLogger();
             var config = new MonkeyConfig

--- a/Tests/Runtime/Operators/ClickOperatorTest.cs
+++ b/Tests/Runtime/Operators/ClickOperatorTest.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using NUnit.Framework;
 using TestHelper.Attributes;
-using TestHelper.Monkey.ScreenPointStrategies;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -24,7 +23,7 @@ namespace TestHelper.Monkey.Operators
                 .First(x => x.gameObject.name == targetName);
 
             Assert.That(target.CanClick(), Is.True);
-            target.Click(DefaultScreenPointStrategy.GetScreenPoint);
+            target.Click();
             LogAssert.Expect(LogType.Log, $"{targetName}.{expectedMessage}");
         }
 
@@ -37,7 +36,7 @@ namespace TestHelper.Monkey.Operators
                 .First(x => x.gameObject.name == targetName);
 
             Assert.That(target.CanTap(), Is.True);
-            target.Tap(DefaultScreenPointStrategy.GetScreenPoint);
+            target.Tap();
             LogAssert.Expect(LogType.Log, $"{targetName}.{expectedMessage}");
         }
 

--- a/Tests/Runtime/Operators/ClickOperatorTest.cs
+++ b/Tests/Runtime/Operators/ClickOperatorTest.cs
@@ -20,7 +20,7 @@ namespace TestHelper.Monkey.Operators
         [LoadScene(TestScene)]
         public void Click(string targetName, string expectedMessage)
         {
-            var target = InteractiveComponentCollector.FindInteractableComponents()
+            var target = new InteractiveComponentCollector().FindInteractableComponents()
                 .First(x => x.gameObject.name == targetName);
 
             Assert.That(target.CanClick(), Is.True);
@@ -33,7 +33,7 @@ namespace TestHelper.Monkey.Operators
         [LoadScene(TestScene)]
         public void Tap(string targetName, string expectedMessage) // Same as Click
         {
-            var target = InteractiveComponentCollector.FindInteractableComponents()
+            var target = new InteractiveComponentCollector().FindInteractableComponents()
                 .First(x => x.gameObject.name == targetName);
 
             Assert.That(target.CanTap(), Is.True);
@@ -46,7 +46,7 @@ namespace TestHelper.Monkey.Operators
         [LoadScene(TestScene)]
         public void CanNotClick(string targetName)
         {
-            var target = InteractiveComponentCollector.FindInteractableComponents()
+            var target = new InteractiveComponentCollector().FindInteractableComponents()
                 .First(x => x.gameObject.name == targetName);
 
             Assert.That(target.CanClick(), Is.False);

--- a/Tests/Runtime/Operators/TextInputOperatorTest.cs
+++ b/Tests/Runtime/Operators/TextInputOperatorTest.cs
@@ -20,7 +20,7 @@ namespace TestHelper.Monkey.Operators
         [LoadScene(TestScene)]
         public void InputText(string targetName)
         {
-            var target = InteractiveComponentCollector.FindInteractableComponents()
+            var target = new InteractiveComponentCollector().FindInteractableComponents()
                 .First(x => x.gameObject.name == targetName);
 
             Assert.That(target.CanTextInput(), Is.True);
@@ -42,7 +42,7 @@ namespace TestHelper.Monkey.Operators
         [LoadScene(TestScene)]
         public void CanNotInputText(string targetName)
         {
-            var target = InteractiveComponentCollector.FindInteractableComponents()
+            var target = new InteractiveComponentCollector().FindInteractableComponents()
                 .First(x => x.gameObject.name == targetName);
 
             Assert.That(target.CanTextInput(), Is.False);

--- a/Tests/Runtime/Operators/TouchAndHoldOperatorTest.cs
+++ b/Tests/Runtime/Operators/TouchAndHoldOperatorTest.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
-using TestHelper.Monkey.ScreenPointStrategies;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -26,7 +25,7 @@ namespace TestHelper.Monkey.Operators
                 .First(x => x.gameObject.name == targetName);
 
             Assert.That(target.CanTouchAndHold(), Is.True);
-            await target.TouchAndHold(DefaultScreenPointStrategy.GetScreenPoint);
+            await target.TouchAndHold();
             LogAssert.Expect(LogType.Log, $"{targetName}.{expectedMessage1}");
             LogAssert.Expect(LogType.Log, $"{targetName}.{expectedMessage2}");
         }

--- a/Tests/Runtime/Operators/TouchAndHoldOperatorTest.cs
+++ b/Tests/Runtime/Operators/TouchAndHoldOperatorTest.cs
@@ -22,7 +22,7 @@ namespace TestHelper.Monkey.Operators
         [LoadScene(TestScene)]
         public async Task TouchAndHold(string targetName, string expectedMessage1, string expectedMessage2)
         {
-            var target = InteractiveComponentCollector.FindInteractableComponents()
+            var target = new InteractiveComponentCollector().FindInteractableComponents()
                 .First(x => x.gameObject.name == targetName);
 
             Assert.That(target.CanTouchAndHold(), Is.True);
@@ -36,7 +36,7 @@ namespace TestHelper.Monkey.Operators
         [LoadScene(TestScene)]
         public void CanNotTouchAndHold(string targetName)
         {
-            var target = InteractiveComponentCollector.FindInteractableComponents()
+            var target = new InteractiveComponentCollector().FindInteractableComponents()
                 .First(x => x.gameObject.name == targetName);
 
             Assert.That(target.CanTouchAndHold(), Is.False);


### PR DESCRIPTION
### Overview
Refactor relative to #102

### Changes
- Add and use ScreenPointStrategy and ReachableStrategy into instance field of InteractiveComponent
- Add and use ScreenPointStrategy, ComponentInteractableStrategy, and ReachableStrategy into instance field of InteractiveComponentCollector
- Remove ScreenPointStrategy from parameter of InteractiveComponent operator methods