### PR TITLE
Remove defineConstraints from annotation assembly

### DIFF
--- a/Annotations/TestHelper.Monkey.Annotations.asmdef
+++ b/Annotations/TestHelper.Monkey.Annotations.asmdef
@@ -8,9 +8,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": [
-        "UNITY_INCLUDE_TESTS || COM_NOWSPRINTING_TEST_HELPER_ENABLE"
-    ],
+    "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ More customize for your project:
 
 You can control the Monkey's behavior by attaching the annotation components to the GameObject.
 
+> [!NOTE]  
+> Since links with annotation components remain in the scenes and prefabs, a warning log will be generated at the time of instantiate.
+> To avoid this, annotation assembly are included in release builds.
+
 #### IgnoreAnnotation
 
 Monkey will not operate objects with `IgnoreAnnotation` attached.


### PR DESCRIPTION
Since links with annotation components remain in the scenes and prefabs, a warning log will be generated at the time of instantiate.
To avoid this, annotation assembly are included in release builds.