### PR TITLE
Obsolete InteractiveComponent class

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Specify the screen position offset on world space where Monkey operates.
 Specify the world position where Monkey operates.
 
 
-### Find and operate interactive uGUI elements API
+### Find and operate interactable uGUI components
 
 #### GameObjectFinder.FindByNameAsync
 
@@ -154,18 +154,17 @@ public class MyIntegrationTest
     [Test]
     public void MyTestMethod()
     {
-        var finder = new GameObjectFinder(5d); // 5 seconds timeout
+        var finder = new GameObjectFinder();
         var button = await finder.FindByPathAsync("/**/Confirm/**/Cancel", reachable: true, interactable: true);
     }
 }
 ```
 
-#### InteractiveComponent and Operators
+#### Get interactable components and operators
 
-##### InteractiveComponent
-Returns new `InteractableComponent` instance from GameObject. If GameObject is not interactable so, return null.
+`GetInteractableComponents` are extensions of `GameObject` that return interactable components.
 
-##### Operators
+`SelectOperators` and `SelectOperatorsOfType` are extensions of `Component` that return available operators.
 Operators implements `IOperator` interface. It has `OperateAsync` method that operates on the component.
 
 Usage:
@@ -178,14 +177,14 @@ using TestHelper.Monkey;
 public class MyIntegrationTest
 {
     [Test]
-    public void MyTestMethod()
+    public void ClickStartButton()
     {
         var finder = new GameObjectFinder();
         var button = await finder.FindByNameAsync("StartButton", interactable: true);
 
-        var interactableComponent = InteractiveComponent.CreateInteractableComponent(button);
-        var clickOperator = interactableComponent.GetOperatorsByType(OperatorType.Click).First();
-        clickOperator.OperateAsync(interactableComponent.component);
+        var buttonComponent = button.GetInteractableComponents().First();
+        var clickOperator = buttonComponent.SelectOperatorsOfType(_operators, OperatorType.Click).First();
+        clickOperator.OperateAsync(buttonComponent);
     }
 }
 ```
@@ -211,8 +210,8 @@ public class MyIntegrationTest
         var components = InteractiveComponentCollector.FindInteractableComponents();
 
         var firstComponent = components.First();
-        var clickAndHoldOperator = firstComponent.GetOperatorsByType(OperatorType.ClickAndHold).First();
-        await clickAndHoldOperator.OperateAsync(firstComponent.component);
+        var clickAndHoldOperator = firstComponent.SelectOperatorsOfType(_operators, OperatorType.ClickAndHold).First();
+        await clickAndHoldOperator.OperateAsync(firstComponent);
     }
 }
 ```
@@ -239,8 +238,8 @@ public class MyIntegrationTest
         var components = InteractiveComponentCollector.FindReachableInteractableComponents();
 
         var firstComponent = components.First();
-        var textInputOperator = firstComponent.GetOperatorsByType(OperatorType.TextInput).First();
-        textInputOperator.OperateAsync(firstComponent.component);   // input random text
+        var textInputOperator = firstComponent.SelectOperatorsOfType(_operators, OperatorType.TextInput).First();
+        textInputOperator.OperateAsync(firstComponent);   // input random text
     }
 }
 ```

--- a/Runtime/Extensions/ComponentExtensions.cs
+++ b/Runtime/Extensions/ComponentExtensions.cs
@@ -2,7 +2,9 @@
 // This software is released under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using TestHelper.Monkey.Operators;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -11,6 +13,31 @@ namespace TestHelper.Monkey.Extensions
 {
     public static class ComponentExtensions
     {
+        /// <summary>
+        /// Returns the operators available to this component.
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="operators">All available operators in autopilot/tests. Usually defined in <c>MonkeyConfig</c></param>
+        /// <returns>Available operators</returns>
+        public static IEnumerable<IOperator> SelectOperators(this Component component,
+            IEnumerable<IOperator> operators)
+        {
+            return operators.Where(iOperator => iOperator.CanOperate(component));
+        }
+
+        /// <summary>
+        /// Returns the operators that specify types and are available to this component.
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="operators">All available operators in autopilot/tests. Usually defined in <c>MonkeyConfig</c></param>
+        /// <param name="type">Operator type</param>
+        /// <returns>Available operators</returns>
+        public static IEnumerable<IOperator> SelectOperatorsOfType(this Component component,
+            IEnumerable<IOperator> operators, OperatorType type)
+        {
+            return operators.Where(iOperator => iOperator.Type == type && iOperator.CanOperate(component));
+        }
+
         /// <summary>
         /// Make sure the <c>Component</c> is interactable.
         /// If any of the following is true:

--- a/Runtime/Extensions/GameObjectExtensions.cs
+++ b/Runtime/Extensions/GameObjectExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TestHelper.Monkey.DefaultStrategies;
 using TestHelper.Monkey.ScreenPointStrategies;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -56,6 +57,30 @@ namespace TestHelper.Monkey.Extensions
             }
 
             return canvas.renderMode == RenderMode.ScreenSpaceOverlay ? null : canvas.worldCamera;
+        }
+
+        /// <summary>
+        /// Hit test using raycaster
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <param name="isReachable">The function returns the <c>GameObject</c> is reachable from user or not.
+        /// Default is <c>DefaultReachableStrategy.IsReachable</c>.</param>
+        /// <param name="pointerEventData">Specify if avoid GC memory allocation</param>
+        /// <param name="raycastResults">Specify if avoid GC memory allocation</param>
+        /// <returns>true: this object can control by user</returns>
+        public static bool IsReachable(this GameObject gameObject,
+            Func<GameObject, PointerEventData, List<RaycastResult>, bool> isReachable = null,
+            PointerEventData pointerEventData = null,
+            List<RaycastResult> raycastResults = null)
+        {
+            Assert.IsNotNull(EventSystem.current);
+
+            isReachable = isReachable ?? DefaultReachableStrategy.IsReachable;
+            pointerEventData = pointerEventData ?? new PointerEventData(EventSystem.current);
+            raycastResults = raycastResults ?? new List<RaycastResult>();
+
+            raycastResults.Clear();
+            return isReachable.Invoke(gameObject, pointerEventData, raycastResults);
         }
 
         /// <summary>

--- a/Runtime/Extensions/GameObjectExtensions.cs
+++ b/Runtime/Extensions/GameObjectExtensions.cs
@@ -128,6 +128,20 @@ namespace TestHelper.Monkey.Extensions
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <param name="isComponentInteractable"></param>
+        /// <returns></returns>
+        public static IEnumerable<Component> GetInteractableComponents(this GameObject gameObject,
+            Func<Component, bool> isComponentInteractable = null)
+        {
+            isComponentInteractable = isComponentInteractable ?? DefaultComponentInteractableStrategy.IsInteractable;
+
+            return gameObject.GetComponents<Component>().Where(x => isComponentInteractable.Invoke(x));
+        }
+
+        /// <summary>
         /// Make sure the <c>GameObject</c> is interactable.
         /// If any of the following is true:
         /// 1. Attached <c>Selectable</c> component and <c>interactable</c> property is true.

--- a/Runtime/Hints/InteractiveComponentHint.cs
+++ b/Runtime/Hints/InteractiveComponentHint.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Text;
+using TestHelper.Monkey.DefaultStrategies;
 using TestHelper.Monkey.Extensions;
 using TestHelper.Monkey.ScreenPointStrategies;
 using UnityEngine;
@@ -101,7 +102,7 @@ namespace TestHelper.Monkey.Hints
             var interactiveComponentCollector = new InteractiveComponentCollector();
             foreach (var component in interactiveComponentCollector.FindInteractableComponents())
             {
-                var dst = component.IsReachable()
+                var dst = component.gameObject.IsReachable(isReachable: DefaultReachableStrategy.IsReachable)
                     ? _tmpReallyInteractives
                     : _tmpNotReallyInteractives;
 

--- a/Runtime/InteractiveComponent.cs
+++ b/Runtime/InteractiveComponent.cs
@@ -18,7 +18,7 @@ namespace TestHelper.Monkey
     /// <summary>
     /// Wrapped component that provide interaction for user.
     /// </summary>
-    // TODO: Rename to InteractableComponent
+    [Obsolete]
     public class InteractiveComponent
     {
         /// <summary>

--- a/Runtime/InteractiveComponent.cs
+++ b/Runtime/InteractiveComponent.cs
@@ -135,14 +135,10 @@ namespace TestHelper.Monkey
         /// Returns the operators available to this component.
         /// </summary>
         /// <returns>Available operators</returns>
+        [Obsolete("Use ComponentExtensions.SelectOperators() instead.")]
         public IEnumerable<IOperator> GetOperators()
         {
-            if (_operators == null || !_operators.Any())
-            {
-                throw new NotSupportedException("Operators are not set.");
-            }
-
-            return _operators.Where(iOperator => iOperator.CanOperate(component));
+            return component.SelectOperators(_operators);
         }
 
         /// <summary>
@@ -150,14 +146,10 @@ namespace TestHelper.Monkey
         /// </summary>
         /// <param name="type">Operator type</param>
         /// <returns>Available operators</returns>
+        [Obsolete("Use ComponentExtensions.SelectOperatorsOfType() instead.")]
         public IEnumerable<IOperator> GetOperatorsByType(OperatorType type)
         {
-            if (_operators == null || !_operators.Any())
-            {
-                throw new NotSupportedException("Operators are not set.");
-            }
-
-            return _operators.Where(iOperator => iOperator.Type == type && iOperator.CanOperate(component));
+            return component.SelectOperatorsOfType(_operators, type);
         }
 
         /// <summary>

--- a/Runtime/InteractiveComponent.cs
+++ b/Runtime/InteractiveComponent.cs
@@ -125,9 +125,10 @@ namespace TestHelper.Monkey
         /// Hit test using raycaster
         /// </summary>
         /// <returns>true: this object can control by user</returns>
+        [Obsolete("Use GameObjectExtensions.IsReachable() instead")]
         public bool IsReachable()
         {
-            return _isReachable.Invoke(gameObject, _eventData, _results);
+            return gameObject.IsReachable(_isReachable, _eventData, _results);
         }
 
         /// <summary>

--- a/Runtime/InteractiveComponentCollector.cs
+++ b/Runtime/InteractiveComponentCollector.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using TestHelper.Monkey.DefaultStrategies;
+using TestHelper.Monkey.Extensions;
 using TestHelper.Monkey.Operators;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -47,17 +49,14 @@ namespace TestHelper.Monkey
         ///
         /// Note: If you only need UI elements, using UnityEngine.UI.Selectable.allSelectablesArray is faster.
         /// </summary>
-        /// <returns>Interactive components</returns>
-        public IEnumerable<InteractiveComponent> FindInteractableComponents()
+        /// <returns>Interactable components</returns>
+        public IEnumerable<Component> FindInteractableComponents()
         {
             foreach (var component in FindMonoBehaviours())
             {
                 if (_isInteractable.Invoke(component))
                 {
-                    yield return InteractiveComponent.CreateInteractableComponent(component,
-                        _isReachable,
-                        _isInteractable,
-                        _operators);
+                    yield return component;
                 }
             }
         }
@@ -65,8 +64,7 @@ namespace TestHelper.Monkey
         [Obsolete("Use FindInteractableComponents() instead")]
         public static IEnumerable<InteractiveComponent> FindInteractiveComponents()
         {
-            var instance = new InteractiveComponentCollector();
-            return instance.FindInteractableComponents();
+            throw new NotImplementedException("Use FindInteractableComponents() instead");
         }
 
         /// <summary>
@@ -75,24 +73,33 @@ namespace TestHelper.Monkey
         /// 
         /// Note: If you only need UI elements, using UnityEngine.UI.Selectable.allSelectablesArray is faster.
         /// </summary>
-        /// <returns>Really interactive components</returns>
-        public IEnumerable<InteractiveComponent> FindReachableInteractableComponents()
+        /// <returns>Reachable and Interactable components</returns>
+        public IEnumerable<Component> FindReachableInteractableComponents()
         {
-            foreach (var interactiveComponent in FindInteractableComponents())
+            foreach (var interactableComponent in FindInteractableComponents())
             {
-                if (_isReachable.Invoke(interactiveComponent.gameObject, _eventData, _results))
+                if (_isReachable.Invoke(interactableComponent.gameObject, _eventData, _results))
                 {
-                    yield return interactiveComponent;
+                    yield return interactableComponent;
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns tuple of interactable component and operator.
+        /// Note: Not check reachable from user.
+        /// </summary>
+        /// <returns>Tuple of interactable component and operator</returns>
+        public IEnumerable<(Component, IOperator)> FindInteractableComponentsAndOperators()
+        {
+            return FindInteractableComponents().SelectMany(x => x.SelectOperators(_operators), (x, o) => (x, o));
         }
 
         [Obsolete("Use FindReachableInteractableComponents() instead")]
         public static IEnumerable<InteractiveComponent> FindReallyInteractiveComponents(
             Func<GameObject, Vector2> screenPointStrategy)
         {
-            var instance = new InteractiveComponentCollector();
-            return instance.FindReachableInteractableComponents();
+            throw new NotImplementedException("Use FindReachableInteractableComponents() instead");
         }
 
         private static IEnumerable<MonoBehaviour> FindMonoBehaviours()

--- a/Samples~/uGUI Demo/Tests/Runtime/ScenarioTest.cs
+++ b/Samples~/uGUI Demo/Tests/Runtime/ScenarioTest.cs
@@ -5,9 +5,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
+using TestHelper.Monkey.Extensions;
 using TestHelper.Monkey.Operators;
-using UnityEngine;
-using UnityEngine.UI;
 
 namespace TestHelper.Monkey.Samples.UGUIDemo
 {
@@ -30,32 +29,27 @@ namespace TestHelper.Monkey.Samples.UGUIDemo
 
             // When click Start button, then open Home screen.
             var startButton = await _finder.FindByNameAsync("StartButton", interactable: true);
-            var startComponent = CreateInteractableComponent(startButton.GetComponent<Button>());
-            var startClickOperator = startComponent.GetOperatorsByType(OperatorType.Click).First();
-            startClickOperator.OperateAsync(startComponent.component);
+            var startComponent = startButton.GetInteractableComponents().First();
+            var startOperator = startComponent.SelectOperatorsOfType(_config.Operators, OperatorType.Click).First();
+            startOperator.OperateAsync(startComponent);
 
             await _finder.FindByNameAsync("Home");
 
             // When click target button, then open target screen.
             var targetButton = await _finder.FindByNameAsync($"{target}Button", interactable: true);
-            var targetComponent = CreateInteractableComponent(targetButton.GetComponent<Button>());
-            var targetClickOperator = targetComponent.GetOperatorsByType(OperatorType.Click).First();
-            targetClickOperator.OperateAsync(targetComponent.component);
+            var targetComponent = targetButton.GetInteractableComponents().First();
+            var targetOperator = targetComponent.SelectOperatorsOfType(_config.Operators, OperatorType.Click).First();
+            targetOperator.OperateAsync(targetComponent);
 
             await _finder.FindByNameAsync(target);
 
             // When click Back button, then return Home screen.
             var backButton = await _finder.FindByPathAsync($"**/{target}/BackButton", interactable: true);
-            var backComponent = CreateInteractableComponent(backButton.GetComponent<Button>());
-            var backClickOperator = backComponent.GetOperatorsByType(OperatorType.Click).First();
-            backClickOperator.OperateAsync(backComponent.component);
+            var backComponent = backButton.GetInteractableComponents().First();
+            var backOperator = backComponent.SelectOperatorsOfType(_config.Operators, OperatorType.Click).First();
+            backOperator.OperateAsync(backComponent);
 
             await _finder.FindByNameAsync("Home");
-        }
-
-        private InteractiveComponent CreateInteractableComponent(MonoBehaviour component)
-        {
-            return InteractiveComponent.CreateInteractableComponent(component, operators: _config.Operators);
         }
     }
 }

--- a/Tests/Runtime/Annotations/PositionAnnotationTest.cs
+++ b/Tests/Runtime/Annotations/PositionAnnotationTest.cs
@@ -4,6 +4,8 @@
 using System.Linq;
 using NUnit.Framework;
 using TestHelper.Attributes;
+using TestHelper.Monkey.DefaultStrategies;
+using TestHelper.Monkey.Extensions;
 
 namespace TestHelper.Monkey.Annotations
 {
@@ -31,7 +33,7 @@ namespace TestHelper.Monkey.Annotations
             // Without no position annotations, IsReallyInteractiveFromUser() is always false because
             // gameObject.transform.position is not in the mesh. So IsReallyInteractiveFromUser() is true means
             // the position annotation work well
-            Assert.That(target.IsReachable(), Is.True);
+            Assert.That(target.gameObject.IsReachable(DefaultReachableStrategy.IsReachable), Is.True);
         }
     }
 }

--- a/Tests/Runtime/Extensions/ComponentExtensionsTest.cs
+++ b/Tests/Runtime/Extensions/ComponentExtensionsTest.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using TestHelper.Monkey.Operators;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TestHelper.Monkey.Extensions
+{
+    public class ComponentExtensionsTest
+    {
+        private static readonly IOperator s_clickOperator = new UGUIClickOperator();
+        private static readonly IOperator s_clickAndHoldOperator = new UGUIClickAndHoldOperator();
+        private static readonly IOperator s_textInputOperator = new UGUITextInputOperator();
+
+        private readonly IEnumerable<IOperator> _operators = new[]
+        {
+            s_clickOperator, s_clickAndHoldOperator, // Matches UnityEngine.UI.Button
+            s_textInputOperator, // Does not match UnityEngine.UI.Button
+        };
+
+        [Test]
+        public void GetOperators_Button_GotClickAndClickAndHoldOperator()
+        {
+            var button = new GameObject().AddComponent<Button>();
+            var actual = button.SelectOperators(_operators);
+
+            Assert.That(actual, Is.EquivalentTo(new[] { s_clickOperator, s_clickAndHoldOperator }));
+        }
+
+        [Test]
+        public void GetOperatorsByType_Button_GotClickOperator()
+        {
+            var button = new GameObject().AddComponent<Button>();
+            var actual = button.SelectOperatorsOfType(_operators, OperatorType.Click);
+
+            Assert.That(actual, Is.EquivalentTo(new[] { s_clickOperator }));
+        }
+    }
+}

--- a/Tests/Runtime/Extensions/ComponentExtensionsTest.cs.meta
+++ b/Tests/Runtime/Extensions/ComponentExtensionsTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 63914e395b414579a96ccface797530a
+timeCreated: 1713580344

--- a/Tests/Runtime/Extensions/GameObjectExtensionsTest.cs
+++ b/Tests/Runtime/Extensions/GameObjectExtensionsTest.cs
@@ -7,9 +7,11 @@ using Cysharp.Threading.Tasks; // Do not remove, required for Unity 2022 or earl
 using NUnit.Framework;
 using TestHelper.Attributes;
 using TestHelper.Monkey.DefaultStrategies;
+using TestHelper.Monkey.TestDoubles;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
+using UnityEngine.UI;
 #if UNITY_EDITOR
 using UnityEditor.SceneManagement;
 #endif
@@ -107,6 +109,28 @@ namespace TestHelper.Monkey.Extensions
                 Assert.That(actual.IsReachable(DefaultReachableStrategy.IsReachable), Is.False);
                 // TODO: Remove argument after remove obsolete method
             }
+        }
+
+        [Test]
+        public void GetInteractableComponents_GotInteractableComponents()
+        {
+            var gameObject = new GameObject();
+            var onPointerClickHandler = gameObject.AddComponent<SpyOnPointerClickHandler>();
+            var onPointerDownUpHandler = gameObject.AddComponent<SpyOnPointerDownUpHandler>();
+            gameObject.AddComponent<Image>(); // Not interactable
+
+            var actual = gameObject.GetInteractableComponents();
+            Assert.That(actual, Is.EquivalentTo(new Component[] { onPointerClickHandler, onPointerDownUpHandler }));
+        }
+
+        [Test]
+        public void GetInteractableComponents_NoInteractableComponents_ReturnsEmpty()
+        {
+            var button = new GameObject().AddComponent<Button>();
+            button.interactable = false;
+
+            var actual = button.gameObject.GetInteractableComponents();
+            Assert.That(actual, Is.Empty);
         }
     }
 }

--- a/Tests/Runtime/Extensions/GameObjectExtensionsTest.cs
+++ b/Tests/Runtime/Extensions/GameObjectExtensionsTest.cs
@@ -1,0 +1,112 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Linq; // Do not remove, required for Unity 2022 or earlier
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks; // Do not remove, required for Unity 2022 or earlier
+using NUnit.Framework;
+using TestHelper.Attributes;
+using TestHelper.Monkey.DefaultStrategies;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+#if UNITY_EDITOR
+using UnityEditor.SceneManagement;
+#endif
+
+namespace TestHelper.Monkey.Extensions
+{
+    [TestFixture]
+    public class GameObjectExtensionsTest
+    {
+        [TestFixture(RenderMode.ScreenSpaceOverlay)]
+        [TestFixture(RenderMode.ScreenSpaceCamera)]
+        [TestFixture(RenderMode.WorldSpace)]
+        public class UI
+        {
+            private const string TestScenePath =
+                "Packages/com.nowsprinting.test-helper.monkey/Tests/Scenes/GameObjectFinderUI.unity";
+
+            private readonly GameObjectFinder _sut = new GameObjectFinder(0.1d);
+            private readonly RenderMode _canvasRenderMode;
+
+            public UI(RenderMode canvasRenderMode)
+            {
+                _canvasRenderMode = canvasRenderMode;
+            }
+
+            [SetUp]
+            public void SetUp()
+            {
+                var canvas = GameObject.Find("Canvas").GetComponent<Canvas>();
+                canvas.renderMode = _canvasRenderMode;
+                if (_canvasRenderMode == RenderMode.WorldSpace)
+                {
+                    canvas.worldCamera = Camera.main;
+                    canvas.transform.position = new Vector3(0, 0, 500);
+                }
+            }
+
+            [TestCase("ActiveText")]
+            [TestCase("Dialog")] // Child objects do not block raycast
+            [LoadScene(TestScenePath)]
+            public async Task IsReachable_Reachable(string target)
+            {
+                var actual = await _sut.FindByNameAsync(target, reachable: false);
+                Assert.That(actual.IsReachable(DefaultReachableStrategy.IsReachable), Is.True);
+                // TODO: Remove argument after remove obsolete method
+            }
+
+            [TestCase("OutOfSight")]
+            [TestCase("BehindTheWall")]
+            [LoadScene(TestScenePath)]
+            public async Task IsReachable_NotReachable(string target)
+            {
+                var actual = await _sut.FindByNameAsync(target, reachable: false);
+                Assert.That(actual.IsReachable(DefaultReachableStrategy.IsReachable), Is.False);
+                // TODO: Remove argument after remove obsolete method
+            }
+        }
+
+        [TestFixture("2D")]
+        [TestFixture("3D")]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
+        public class Object
+        {
+            private readonly GameObjectFinder _sut = new GameObjectFinder(0.1d);
+            private readonly string _testScenePath;
+
+            public Object(string dimension)
+            {
+                _testScenePath =
+                    $"Packages/com.nowsprinting.test-helper.monkey/Tests/Scenes/GameObjectFinder{dimension}.unity";
+            }
+
+            [SetUp]
+            public async Task SetUp()
+            {
+#if UNITY_EDITOR
+                await EditorSceneManager.LoadSceneAsyncInPlayMode(_testScenePath,
+                    new LoadSceneParameters(LoadSceneMode.Single));
+#endif
+            }
+
+            [TestCase("NotInteractable")]
+            public async Task IsReachable_Reachable(string target)
+            {
+                var actual = await _sut.FindByNameAsync(target, reachable: false);
+                Assert.That(actual.IsReachable(DefaultReachableStrategy.IsReachable), Is.True);
+                // TODO: Remove argument after remove obsolete method
+            }
+
+            [TestCase("OutOfSight")]
+            [TestCase("BehindTheWall")]
+            public async Task IsReachable_NotReachable(string target)
+            {
+                var actual = await _sut.FindByNameAsync(target, reachable: false);
+                Assert.That(actual.IsReachable(DefaultReachableStrategy.IsReachable), Is.False);
+                // TODO: Remove argument after remove obsolete method
+            }
+        }
+    }
+}

--- a/Tests/Runtime/Extensions/GameObjectExtensionsTest.cs.meta
+++ b/Tests/Runtime/Extensions/GameObjectExtensionsTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: eaa50786b6a14cb5b0e502e0bb005d6f
+timeCreated: 1713578111

--- a/Tests/Runtime/InteractiveComponentTest.cs
+++ b/Tests/Runtime/InteractiveComponentTest.cs
@@ -145,22 +145,6 @@ namespace TestHelper.Monkey
             }
 
             [Test]
-            public void GetOperators_OperatorsNotSet_ThrowsNotSupportedException()
-            {
-                var button = new GameObject().AddComponent<Button>();
-                var sut = InteractiveComponent.CreateInteractableComponent(button); // operators not set
-                try
-                {
-                    sut.GetOperators();
-                    Assert.Fail("Expected exception was not thrown");
-                }
-                catch (System.NotSupportedException e)
-                {
-                    Assert.That(e.Message, Is.EqualTo("Operators are not set."));
-                }
-            }
-
-            [Test]
             public void GetOperatorsByType_Button_GotClickOperator()
             {
                 var button = new GameObject().AddComponent<Button>();
@@ -168,22 +152,6 @@ namespace TestHelper.Monkey
                 var actual = sut.GetOperatorsByType(OperatorType.Click);
 
                 Assert.That(actual, Is.EquivalentTo(new[] { s_clickOperator }));
-            }
-
-            [Test]
-            public void GetOperatorsByType_OperatorsNotSet_ThrowsNotSupportedException()
-            {
-                var button = new GameObject().AddComponent<Button>();
-                var sut = InteractiveComponent.CreateInteractableComponent(button); // operators not set
-                try
-                {
-                    sut.GetOperatorsByType(OperatorType.Click);
-                    Assert.Fail("Expected exception was not thrown");
-                }
-                catch (System.NotSupportedException e)
-                {
-                    Assert.That(e.Message, Is.EqualTo("Operators are not set."));
-                }
             }
 
             [Test]

--- a/Tests/Runtime/InteractiveComponentTest.cs
+++ b/Tests/Runtime/InteractiveComponentTest.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
+using TestHelper.Monkey.DefaultStrategies;
+using TestHelper.Monkey.Extensions;
 using TestHelper.Monkey.Operators;
 using TestHelper.Monkey.TestDoubles;
 using UnityEngine;
@@ -67,7 +69,7 @@ namespace TestHelper.Monkey
                 var target = new InteractiveComponentCollector().FindInteractableComponents()
                     .First(x => x.gameObject.name == targetName);
 
-                Assert.That(target.IsReachable(), Is.True);
+                Assert.That(target.gameObject.IsReachable(DefaultReachableStrategy.IsReachable), Is.True);
             }
 
             [TestCase("BeyondTheWall")] // Beyond the another object
@@ -78,7 +80,7 @@ namespace TestHelper.Monkey
                 var target = new InteractiveComponentCollector().FindInteractableComponents()
                     .First(x => x.gameObject.name == targetName);
 
-                Assert.That(target.IsReachable(), Is.False);
+                Assert.That(target.gameObject.IsReachable(DefaultReachableStrategy.IsReachable), Is.False);
             }
         }
 
@@ -102,7 +104,7 @@ namespace TestHelper.Monkey
                 var target = new InteractiveComponentCollector().FindInteractableComponents()
                     .First(x => x.gameObject.name == targetName);
 
-                Assert.That(target.IsReachable(), Is.True);
+                Assert.That(target.gameObject.IsReachable(DefaultReachableStrategy.IsReachable), Is.True);
             }
 
             [TestCase("BeyondTheWall")] // Beyond the another object
@@ -117,7 +119,7 @@ namespace TestHelper.Monkey
                 var target = new InteractiveComponentCollector().FindInteractableComponents()
                     .First(x => x.gameObject.name == targetName);
 
-                Assert.That(target.IsReachable(), Is.False);
+                Assert.That(target.gameObject.IsReachable(DefaultReachableStrategy.IsReachable), Is.False);
             }
         }
 


### PR DESCRIPTION
### Changes
- Obsolete `InteractiveComponent` class
- Add `ComponentExtensions.SelectOperators` and `SelectOperatorsOfType`
- Add `GameObjectExtensions.GetInteractableComponents`
- Add `GameObjectExtensions.IsReachable`
- Change `Monkey.RunStep` parameters, Passing only necessary fields instead of `MonkeyConfig`