### PR TITLE
Fix suppress double quote in screenshot filename

### DIFF
--- a/Runtime/ScreenshotFilenameStrategies/AbstractPrefixAndUniqueIDStrategy.cs
+++ b/Runtime/ScreenshotFilenameStrategies/AbstractPrefixAndUniqueIDStrategy.cs
@@ -72,7 +72,9 @@ namespace TestHelper.Monkey.ScreenshotFilenameStrategies
             return TestContext.CurrentTestExecutionContext.CurrentTest.Name
                 .Replace('(', '_')
                 .Replace(')', '_')
-                .Replace(',', '-');
+                .Replace(',', '-')
+                .Replace("\"", "");
+            // Note: Same as the file name created under ActualImages of the Graphics Tests Framework package.
         }
 #endif
 


### PR DESCRIPTION
Condition: when there is a string parameter in a parameterized test