### PR TITLE
Optimize logging and add verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Configurations in `MonkeyConfig`:
 - **SecondsToErrorForNoInteractiveComponent**: Seconds to determine that an error has occurred when an object that can be interacted with does not exist
 - **Random**: Random generator
 - **Logger**: Logger
+- **Verbose**: Output verbose log if true
 - **Gizmos**: Show Gizmos on `GameView` during running monkey test if true
 - **Screenshots**: Take screenshots during running the monkey test if set a `ScreenshotOptions` instance.
     - **Directory**: Directory to save screenshots. If omitted, the directory specified by command line argument "-testHelperScreenshotDirectory" is used. If the command line argument is also omitted, `Application.persistentDataPath` + "/TestHelper/Screenshots/" is used.

--- a/Runtime/DefaultStrategies/DefaultComponentInteractableStrategy.cs
+++ b/Runtime/DefaultStrategies/DefaultComponentInteractableStrategy.cs
@@ -26,7 +26,7 @@ namespace TestHelper.Monkey.DefaultStrategies
         {
             // UI element
             var selectable = component as Selectable;
-            if (selectable != null)
+            if (selectable)
             {
                 return selectable.interactable;
             }

--- a/Runtime/Extensions/GameObjectExtensions.cs
+++ b/Runtime/Extensions/GameObjectExtensions.cs
@@ -68,8 +68,9 @@ namespace TestHelper.Monkey.Extensions
         /// <param name="pointerEventData">Specify if avoid GC memory allocation</param>
         /// <param name="raycastResults">Specify if avoid GC memory allocation</param>
         /// <returns>true: this object can control by user</returns>
+        [Obsolete("Use DefaultReachableStrategy instead.")]
         public static bool IsReachable(this GameObject gameObject,
-            Func<GameObject, PointerEventData, List<RaycastResult>, bool> isReachable = null,
+            Func<GameObject, PointerEventData, List<RaycastResult>, ILogger, bool> isReachable = null,
             PointerEventData pointerEventData = null,
             List<RaycastResult> raycastResults = null)
         {
@@ -80,7 +81,7 @@ namespace TestHelper.Monkey.Extensions
             raycastResults = raycastResults ?? new List<RaycastResult>();
 
             raycastResults.Clear();
-            return isReachable.Invoke(gameObject, pointerEventData, raycastResults);
+            return isReachable.Invoke(gameObject, pointerEventData, raycastResults, null);
         }
 
         /// <summary>

--- a/Runtime/GameObjectFinder.cs
+++ b/Runtime/GameObjectFinder.cs
@@ -20,7 +20,7 @@ namespace TestHelper.Monkey
     public class GameObjectFinder
     {
         private readonly double _timeoutSeconds;
-        private readonly Func<GameObject, PointerEventData, List<RaycastResult>, bool> _isReachable;
+        private readonly Func<GameObject, PointerEventData, List<RaycastResult>, ILogger, bool> _isReachable;
         private readonly Func<Component, bool> _isComponentInteractable;
         private readonly PointerEventData _eventData = new PointerEventData(EventSystem.current);
         private readonly List<RaycastResult> _results = new List<RaycastResult>();
@@ -36,7 +36,7 @@ namespace TestHelper.Monkey
         /// <param name="isComponentInteractable">The function returns the <c>Component</c> is interactable or not.
         /// Default is <c>DefaultComponentInteractableStrategy.IsInteractable</c>.</param>
         public GameObjectFinder(double timeoutSeconds = 1.0d,
-            Func<GameObject, PointerEventData, List<RaycastResult>, bool> isReachable = null,
+            Func<GameObject, PointerEventData, List<RaycastResult>, ILogger, bool> isReachable = null,
             Func<Component, bool> isComponentInteractable = null)
         {
             Assert.IsTrue(timeoutSeconds > MinTimeoutSeconds,
@@ -71,7 +71,7 @@ namespace TestHelper.Monkey
                 return (null, Reason.NotMatchPath);
             }
 
-            if (reachable && !_isReachable.Invoke(foundObject, _eventData, _results))
+            if (reachable && !_isReachable.Invoke(foundObject, _eventData, _results, null))
             {
                 return (null, Reason.NotReachable);
             }

--- a/Runtime/Hints/InteractiveComponentHint.cs
+++ b/Runtime/Hints/InteractiveComponentHint.cs
@@ -102,7 +102,7 @@ namespace TestHelper.Monkey.Hints
             var interactiveComponentCollector = new InteractiveComponentCollector();
             foreach (var component in interactiveComponentCollector.FindInteractableComponents())
             {
-                var dst = component.gameObject.IsReachable(isReachable: DefaultReachableStrategy.IsReachable)
+                var dst = DefaultReachableStrategy.IsReachable(component.gameObject)
                     ? _tmpReallyInteractives
                     : _tmpNotReallyInteractives;
 

--- a/Runtime/InteractiveComponent.cs
+++ b/Runtime/InteractiveComponent.cs
@@ -39,13 +39,13 @@ namespace TestHelper.Monkey
         [SuppressMessage("ReSharper", "InconsistentNaming")]
         public GameObject gameObject => component.gameObject;
 
-        private readonly Func<GameObject, PointerEventData, List<RaycastResult>, bool> _isReachable;
+        private readonly Func<GameObject, PointerEventData, List<RaycastResult>, ILogger, bool> _isReachable;
         private readonly IEnumerable<IOperator> _operators;
         private readonly PointerEventData _eventData = new PointerEventData(EventSystem.current);
         private readonly List<RaycastResult> _results = new List<RaycastResult>();
 
         private InteractiveComponent(MonoBehaviour component,
-            Func<GameObject, PointerEventData, List<RaycastResult>, bool> isReachable = null,
+            Func<GameObject, PointerEventData, List<RaycastResult>, ILogger, bool> isReachable = null,
             IEnumerable<IOperator> operators = null)
         {
             this.component = component;
@@ -64,7 +64,7 @@ namespace TestHelper.Monkey
         /// <param name="operators">All available operators in autopilot/tests. Usually defined in <c>MonkeyConfig</c></param>
         /// <returns>Returns new InteractableComponent instance from MonoBehaviour. If MonoBehaviour is not interactable so, return null.</returns>
         public static InteractiveComponent CreateInteractableComponent(MonoBehaviour component,
-            Func<GameObject, PointerEventData, List<RaycastResult>, bool> isReachable = null,
+            Func<GameObject, PointerEventData, List<RaycastResult>, ILogger, bool> isReachable = null,
             Func<Component, bool> isComponentInteractable = null,
             IEnumerable<IOperator> operators = null)
         {
@@ -90,7 +90,7 @@ namespace TestHelper.Monkey
         /// <returns>Returns new InteractableComponent instance from GameObject. If GameObject is not interactable so, return null.</returns>
         [Obsolete("Obsolete due to non-deterministic behavior when GameObject has multiple interactable components.")]
         public static InteractiveComponent CreateInteractableComponent(GameObject gameObject,
-            Func<GameObject, PointerEventData, List<RaycastResult>, bool> isReachable = null,
+            Func<GameObject, PointerEventData, List<RaycastResult>, ILogger, bool> isReachable = null,
             Func<Component, bool> isComponentInteractable = null,
             IEnumerable<IOperator> operators = null)
         {
@@ -128,7 +128,7 @@ namespace TestHelper.Monkey
         [Obsolete("Use GameObjectExtensions.IsReachable() instead")]
         public bool IsReachable()
         {
-            return gameObject.IsReachable(_isReachable, _eventData, _results);
+            return _isReachable(gameObject, _eventData, _results, null);
         }
 
         /// <summary>

--- a/Runtime/InteractiveComponentCollector.cs
+++ b/Runtime/InteractiveComponentCollector.cs
@@ -19,7 +19,7 @@ namespace TestHelper.Monkey
     // TODO: Rename to InteractableComponentsFinder
     public class InteractiveComponentCollector
     {
-        private readonly Func<GameObject, PointerEventData, List<RaycastResult>, bool> _isReachable;
+        private readonly Func<GameObject, PointerEventData, List<RaycastResult>, ILogger, bool> _isReachable;
         private readonly Func<Component, bool> _isInteractable;
         private readonly IEnumerable<IOperator> _operators;
         private readonly PointerEventData _eventData = new PointerEventData(EventSystem.current);
@@ -34,7 +34,7 @@ namespace TestHelper.Monkey
         /// Default is <c>DefaultComponentInteractableStrategy.IsInteractable</c>.</param>
         /// <param name="operators">All available operators in autopilot/tests. Usually defined in <c>MonkeyConfig</c></param>
         public InteractiveComponentCollector(
-            Func<GameObject, PointerEventData, List<RaycastResult>, bool> isReachable = null,
+            Func<GameObject, PointerEventData, List<RaycastResult>, ILogger, bool> isReachable = null,
             Func<Component, bool> isInteractable = null,
             IEnumerable<IOperator> operators = null)
         {
@@ -87,7 +87,7 @@ namespace TestHelper.Monkey
         {
             foreach (var interactableComponent in FindInteractableComponents())
             {
-                if (_isReachable.Invoke(interactableComponent.gameObject, _eventData, _results))
+                if (_isReachable.Invoke(interactableComponent.gameObject, _eventData, _results, null))
                 {
                     yield return interactableComponent;
                 }

--- a/Runtime/Monkey.cs
+++ b/Runtime/Monkey.cs
@@ -145,11 +145,19 @@ namespace TestHelper.Monkey
             {
                 if (component.gameObject.TryGetComponent(typeof(IgnoreAnnotation), out _))
                 {
-                    dictionary?.TryAdd(component.gameObject, "Ignored");
+                    if (dictionary != null && !dictionary.Keys.Contains(component.gameObject))
+                    {
+                        dictionary.Add(component.gameObject, "Ignored");
+                    }
+
                     continue;
                 }
 
-                dictionary?.TryAdd(component.gameObject, null);
+                if (dictionary != null && !dictionary.Keys.Contains(component.gameObject))
+                {
+                    dictionary.Add(component.gameObject, null);
+                }
+
                 yield return (component, iOperator);
             }
 

--- a/Runtime/MonkeyConfig.cs
+++ b/Runtime/MonkeyConfig.cs
@@ -42,6 +42,11 @@ namespace TestHelper.Monkey
         public ILogger Logger { get; set; } = Debug.unityLogger;
 
         /// <summary>
+        /// Output verbose log if true
+        /// </summary>
+        public bool Verbose { get; set; }
+
+        /// <summary>
         /// Show Gizmos on <c>GameView</c> during running monkey test if true
         /// </summary>
         public bool Gizmos { get; set; }
@@ -55,8 +60,8 @@ namespace TestHelper.Monkey
         /// Function returns the <c>GameObject</c> is reachable from user or not.
         /// This function is include ScreenPointStrategy (GetScreenPoint function).
         /// </summary>
-        public Func<GameObject, PointerEventData, List<RaycastResult>, bool>
-            IsReachable { get; set; } = DefaultReachableStrategy.IsReachable;
+        public Func<GameObject, PointerEventData, List<RaycastResult>, ILogger, bool> IsReachable { get; set; } =
+            DefaultReachableStrategy.IsReachable;
 
         /// <summary>
         /// Function returns the <c>Component</c> is interactable or not.

--- a/Tests/Performance/MonkeyTest.cs
+++ b/Tests/Performance/MonkeyTest.cs
@@ -6,11 +6,10 @@ using System.Linq;
 using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
-using TestHelper.Monkey;
 using Unity.PerformanceTesting;
 using UnityEngine.TestTools;
 
-namespace Tests.Performance
+namespace TestHelper.Monkey
 {
     public class MonkeyTest
     {
@@ -19,14 +18,14 @@ namespace Tests.Performance
         [Test]
         [Performance, Version(MeasurePackageVersion)]
         [LoadScene("../Scenes/Operators.unity")]
-        public void GetOperators_GotAllInteractableComponentAndOperators()
+        public void GetLotteryEntries_GotAllInteractableComponentAndOperators()
         {
             var config = new MonkeyConfig();
             var interactableComponentCollector = new InteractiveComponentCollector(config);
 
             Measure.Method(() =>
                 {
-                    Monkey.GetOperators(interactableComponentCollector);
+                    Monkey.GetLotteryEntries(interactableComponentCollector);
                 })
                 .WarmupCount(5)
                 .MeasurementCount(20)
@@ -41,7 +40,7 @@ namespace Tests.Performance
         {
             var config = new MonkeyConfig();
             var interactableComponentCollector = new InteractiveComponentCollector(config);
-            var operators = Monkey.GetOperators(interactableComponentCollector);
+            var operators = Monkey.GetLotteryEntries(interactableComponentCollector);
 
             Measure.Method(() =>
                 {

--- a/Tests/Performance/TestHelper.Monkey.Performance.Tests.asmdef
+++ b/Tests/Performance/TestHelper.Monkey.Performance.Tests.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "TestHelper.Monkey.Performance.Tests",
-    "rootNamespace": "",
+    "rootNamespace": "TestHelper.Monkey",
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",

--- a/Tests/Runtime/Annotations/PositionAnnotationTest.cs
+++ b/Tests/Runtime/Annotations/PositionAnnotationTest.cs
@@ -33,7 +33,7 @@ namespace TestHelper.Monkey.Annotations
             // Without no position annotations, IsReallyInteractiveFromUser() is always false because
             // gameObject.transform.position is not in the mesh. So IsReallyInteractiveFromUser() is true means
             // the position annotation work well
-            Assert.That(target.gameObject.IsReachable(DefaultReachableStrategy.IsReachable), Is.True);
+            Assert.That(DefaultReachableStrategy.IsReachable(target.gameObject), Is.True);
         }
     }
 }

--- a/Tests/Runtime/DefaultStrategies.meta
+++ b/Tests/Runtime/DefaultStrategies.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4d21b44b3e684217aa15af129b2a7c4b
+timeCreated: 1715431551

--- a/Tests/Runtime/DefaultStrategies/DefaultReachableStrategyTest.cs
+++ b/Tests/Runtime/DefaultStrategies/DefaultReachableStrategyTest.cs
@@ -1,0 +1,147 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Linq; // Do not remove, required for Unity 2022 or earlier
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks; // Do not remove, required for Unity 2022 or earlier
+using NUnit.Framework;
+using TestHelper.Attributes;
+using TestHelper.Monkey.TestDoubles;
+using TestHelper.RuntimeInternals;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace TestHelper.Monkey.DefaultStrategies
+{
+    [TestFixture]
+    public class DefaultReachableStrategyTest
+    {
+        [TestFixture(RenderMode.ScreenSpaceOverlay)]
+        [TestFixture(RenderMode.ScreenSpaceCamera)]
+        [TestFixture(RenderMode.WorldSpace)]
+        public class UI
+        {
+            private const string TestScenePath = "../../Scenes/GameObjectFinderUI.unity";
+            private readonly GameObjectFinder _finder = new GameObjectFinder(0.1d);
+            private readonly RenderMode _canvasRenderMode;
+
+            public UI(RenderMode canvasRenderMode)
+            {
+                _canvasRenderMode = canvasRenderMode;
+            }
+
+            [SetUp]
+            public void SetUp()
+            {
+                var canvas = GameObject.Find("Canvas").GetComponent<Canvas>();
+                canvas.renderMode = _canvasRenderMode;
+                if (_canvasRenderMode == RenderMode.WorldSpace)
+                {
+                    canvas.worldCamera = Camera.main;
+                    canvas.transform.position = new Vector3(0, 0, 500);
+                }
+            }
+
+            [TestCase("ActiveText")]
+            [TestCase("Dialog")] // Child objects do not block raycast
+            [LoadScene(TestScenePath)]
+            public async Task IsReachable_Reachable(string target)
+            {
+                var gameObject = await _finder.FindByNameAsync(target, reachable: false);
+                Assert.That(DefaultReachableStrategy.IsReachable(gameObject), Is.True);
+            }
+
+            [TestCase("OutOfSight")]
+            [TestCase("BehindTheWall")]
+            [LoadScene(TestScenePath)]
+            public async Task IsReachable_NotReachable(string target)
+            {
+                var gameObject = await _finder.FindByNameAsync(target, reachable: false);
+                Assert.That(DefaultReachableStrategy.IsReachable(gameObject), Is.False);
+            }
+        }
+
+        [TestFixture("2D")]
+        [TestFixture("3D")]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
+        public class Object
+        {
+            private readonly GameObjectFinder _finder = new GameObjectFinder(0.1d);
+            private readonly string _testScenePath;
+
+            public Object(string dimension)
+            {
+                _testScenePath = $"../../Scenes/GameObjectFinder{dimension}.unity";
+            }
+
+            [SetUp]
+            public async Task SetUp()
+            {
+                await SceneManagerHelper.LoadSceneAsync(_testScenePath);
+            }
+
+            [TestCase("NotInteractable")]
+            public async Task IsReachable_Reachable(string target)
+            {
+                var gameObject = await _finder.FindByNameAsync(target, reachable: false);
+                Assert.That(DefaultReachableStrategy.IsReachable(gameObject), Is.True);
+            }
+
+            [TestCase("OutOfSight")]
+            [TestCase("BehindTheWall")]
+            public async Task IsReachable_NotReachable(string target)
+            {
+                var gameObject = await _finder.FindByNameAsync(target, reachable: false);
+                Assert.That(DefaultReachableStrategy.IsReachable(gameObject), Is.False);
+            }
+        }
+
+        [TestFixture]
+        public class Verbose
+        {
+            private const string TestScenePath = "../../Scenes/GameObjectFinderUI.unity";
+            private readonly GameObjectFinder _finder = new GameObjectFinder(0.1d);
+
+            [TestCase("ActiveText")]
+            [TestCase("Dialog")] // Child objects do not block raycast
+            [LoadScene(TestScenePath)]
+            public async Task IsReachableWithVerbose_Reachable_NotOutputLog(string target)
+            {
+                var gameObject = await _finder.FindByNameAsync(target, reachable: false);
+                var spyLogger = new SpyLogger();
+                var actual = DefaultReachableStrategy.IsReachable(gameObject, verboseLogger: spyLogger);
+                Assume.That(actual, Is.True);
+
+                Assert.That(spyLogger.Messages, Is.Empty);
+            }
+
+            [Test]
+            [LoadScene(TestScenePath)]
+            public async Task IsReachableWithVerbose_OutOfSight_LogVerboseNotHit()
+            {
+                var gameObject = await _finder.FindByNameAsync("OutOfSight", reachable: false);
+                var spyLogger = new SpyLogger();
+                var actual = DefaultReachableStrategy.IsReachable(gameObject, verboseLogger: spyLogger);
+                Assume.That(actual, Is.False);
+
+                Assert.That(spyLogger.Messages.Count, Is.EqualTo(1));
+                Assert.That(spyLogger.Messages[0], Does.Match(
+                    @"Not reachable to OutOfSight\(\d+\), position=\(\d+,\d+\)\. Raycast is not hit\."));
+            }
+
+            [Test]
+            [LoadScene(TestScenePath)]
+            public async Task IsReachableWithVerbose_BehindOtherObject_LogHitOtherObject()
+            {
+                var gameObject = await _finder.FindByNameAsync("BehindTheWall", reachable: false);
+                var spyLogger = new SpyLogger();
+                var actual = DefaultReachableStrategy.IsReachable(gameObject, verboseLogger: spyLogger);
+                Assume.That(actual, Is.False);
+
+                Assert.That(spyLogger.Messages.Count, Is.EqualTo(1));
+                Assert.That(spyLogger.Messages[0], Does.Match(
+                    @"Not reachable to BehindTheWall\(\d+\), position=\(\d+,\d+\)\. Raycast hit other objects: Wall, BehindTheWall"));
+            }
+        }
+    }
+}

--- a/Tests/Runtime/DefaultStrategies/DefaultReachableStrategyTest.cs.meta
+++ b/Tests/Runtime/DefaultStrategies/DefaultReachableStrategyTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6e1b9deca5534cff851a78c4be96b934
+timeCreated: 1715431561

--- a/Tests/Runtime/Extensions/GameObjectExtensionsTest.cs
+++ b/Tests/Runtime/Extensions/GameObjectExtensionsTest.cs
@@ -56,7 +56,7 @@ namespace TestHelper.Monkey.Extensions
             {
                 var actual = await _sut.FindByNameAsync(target, reachable: false);
                 Assert.That(actual.IsReachable(DefaultReachableStrategy.IsReachable), Is.True);
-                // TODO: Remove argument after remove obsolete method
+                // TODO: Remove when remove obsolete method, Already copied to DefaultReachableStrategyTest.
             }
 
             [TestCase("OutOfSight")]
@@ -66,7 +66,7 @@ namespace TestHelper.Monkey.Extensions
             {
                 var actual = await _sut.FindByNameAsync(target, reachable: false);
                 Assert.That(actual.IsReachable(DefaultReachableStrategy.IsReachable), Is.False);
-                // TODO: Remove argument after remove obsolete method
+                // TODO: Remove when remove obsolete method, Already copied to DefaultReachableStrategyTest.
             }
         }
 
@@ -98,7 +98,7 @@ namespace TestHelper.Monkey.Extensions
             {
                 var actual = await _sut.FindByNameAsync(target, reachable: false);
                 Assert.That(actual.IsReachable(DefaultReachableStrategy.IsReachable), Is.True);
-                // TODO: Remove argument after remove obsolete method
+                // TODO: Remove when remove obsolete method, Already copied to DefaultReachableStrategyTest.
             }
 
             [TestCase("OutOfSight")]
@@ -107,7 +107,7 @@ namespace TestHelper.Monkey.Extensions
             {
                 var actual = await _sut.FindByNameAsync(target, reachable: false);
                 Assert.That(actual.IsReachable(DefaultReachableStrategy.IsReachable), Is.False);
-                // TODO: Remove argument after remove obsolete method
+                // TODO: Remove when remove obsolete method, Already copied to DefaultReachableStrategyTest.
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "changelogUrl": "https://github.com/nowsprinting/test-helper.monkey/releases",
   "dependencies": {
     "com.cysharp.unitask": "2.3.3",
-    "com.nowsprinting.test-helper": "0.6.0",
+    "com.nowsprinting.test-helper": "0.7.1",
     "com.nowsprinting.test-helper.random": "0.3.0",
     "com.unity.ugui": "1.0.0"
   },


### PR DESCRIPTION
### Changes
- Suppress logging screenshot filename (see: https://github.com/nowsprinting/test-helper/pull/80 )
- Unified operates logging includes screenshot filename
- Add take a screenshot when over `SecondsToErrorForNoInteractiveComponent`
- Add `MonkeyConfig.Verbose` option, output lottery entries and failing raycast results if true