### PR TITLE
Ignored GameObject strategy to pluggable

### DIFF
--- a/Runtime/DefaultStrategies/DefaultIgnoreStrategy.cs
+++ b/Runtime/DefaultStrategies/DefaultIgnoreStrategy.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2023-2024 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using TestHelper.Monkey.Annotations;
+using UnityEngine;
+
+namespace TestHelper.Monkey.DefaultStrategies
+{
+    /// <summary>
+    /// Default strategy to examine whether GameObject should be ignored.
+    /// </summary>
+    public static class DefaultIgnoreStrategy
+    {
+        /// <summary>
+        /// Ensure the <c>GameObject</c> is ignored or not.
+        /// Default implementation is to check whether the GameObject has <c>IgnoreAnnotation</c> component.
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <returns>True if GameObject is ignored</returns>
+        public static bool IsIgnored(GameObject gameObject)
+        {
+            return gameObject.TryGetComponent(typeof(IgnoreAnnotation), out _);
+        }
+    }
+}

--- a/Runtime/DefaultStrategies/DefaultIgnoreStrategy.cs.meta
+++ b/Runtime/DefaultStrategies/DefaultIgnoreStrategy.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5c056c73eb854169aa9763b1e4c0c993
+timeCreated: 1727934482

--- a/Runtime/MonkeyConfig.cs
+++ b/Runtime/MonkeyConfig.cs
@@ -64,6 +64,11 @@ namespace TestHelper.Monkey
             DefaultReachableStrategy.IsReachable;
 
         /// <summary>
+        /// Function returns the <c>GameObject</c> is ignored or not.
+        /// </summary>
+        public Func<GameObject, bool> IsIgnored { get; set; } = DefaultIgnoreStrategy.IsIgnored;
+
+        /// <summary>
         /// Function returns the <c>Component</c> is interactable or not.
         /// </summary>
         public Func<Component, bool> IsInteractable { get; set; } = DefaultComponentInteractableStrategy.IsInteractable;

--- a/Tests/Performance/MonkeyTest.cs
+++ b/Tests/Performance/MonkeyTest.cs
@@ -25,7 +25,8 @@ namespace TestHelper.Monkey
 
             Measure.Method(() =>
                 {
-                    Monkey.GetLotteryEntries(interactableComponentCollector);
+                    // ReSharper disable once IteratorMethodResultIsIgnored
+                    Monkey.GetLotteryEntries(interactableComponentCollector, config.IsIgnored);
                 })
                 .WarmupCount(5)
                 .MeasurementCount(20)
@@ -40,7 +41,7 @@ namespace TestHelper.Monkey
         {
             var config = new MonkeyConfig();
             var interactableComponentCollector = new InteractiveComponentCollector(config);
-            var operators = Monkey.GetLotteryEntries(interactableComponentCollector);
+            var operators = Monkey.GetLotteryEntries(interactableComponentCollector, config.IsIgnored);
 
             Measure.Method(() =>
                 {
@@ -67,6 +68,7 @@ namespace TestHelper.Monkey
                         config.Logger,
                         config.Screenshots,
                         config.IsReachable,
+                        config.IsIgnored,
                         interactableComponentCollector)
                     .ToCoroutine();
             }

--- a/Tests/Runtime/MonkeyTest.cs
+++ b/Tests/Runtime/MonkeyTest.cs
@@ -54,6 +54,7 @@ namespace TestHelper.Monkey
                 config.Logger,
                 config.Screenshots,
                 config.IsReachable,
+                config.IsIgnored,
                 _interactiveComponentCollector);
 
             Assert.That(didAct, Is.EqualTo(true));
@@ -74,6 +75,7 @@ namespace TestHelper.Monkey
                 config.Logger,
                 config.Screenshots,
                 config.IsReachable,
+                config.IsIgnored,
                 _interactiveComponentCollector);
 
             Assert.That(didAct, Is.EqualTo(false));
@@ -206,7 +208,7 @@ namespace TestHelper.Monkey
         [LoadScene(TestScene)]
         public void GetLotteryEntries_GotAllInteractableComponentAndOperators()
         {
-            var lotteryEntries = Monkey.GetLotteryEntries(_interactiveComponentCollector);
+            var lotteryEntries = Monkey.GetLotteryEntries(_interactiveComponentCollector, DefaultIgnoreStrategy.IsIgnored);
             var actual = new List<string>();
             foreach (var (component, @operator) in lotteryEntries)
             {
@@ -237,7 +239,7 @@ namespace TestHelper.Monkey
         {
             GameObject.Find("UsingOnPointerClickHandler").AddComponent<IgnoreAnnotation>();
 
-            var lotteryEntries = Monkey.GetLotteryEntries(_interactiveComponentCollector);
+            var lotteryEntries = Monkey.GetLotteryEntries(_interactiveComponentCollector, DefaultIgnoreStrategy.IsIgnored);
             var actual = new List<string>();
             foreach (var (component, _) in lotteryEntries)
             {
@@ -342,6 +344,7 @@ namespace TestHelper.Monkey
                     config.Logger,
                     config.Screenshots,
                     config.IsReachable,
+                    config.IsIgnored,
                     _interactiveComponentCollector);
 
                 Assert.That(_path, Does.Exist);
@@ -376,6 +379,7 @@ namespace TestHelper.Monkey
                     config.Logger,
                     config.Screenshots,
                     config.IsReachable,
+                    config.IsIgnored,
                     _interactiveComponentCollector);
 
                 Assert.That(path, Does.Exist);
@@ -402,6 +406,7 @@ namespace TestHelper.Monkey
                     config.Logger,
                     config.Screenshots,
                     config.IsReachable,
+                    config.IsIgnored,
                     _interactiveComponentCollector);
 
                 Assert.That(_path, Does.Exist);
@@ -430,6 +435,7 @@ namespace TestHelper.Monkey
                     config.Logger,
                     config.Screenshots,
                     config.IsReachable,
+                    config.IsIgnored,
                     _interactiveComponentCollector);
 
                 Assert.That(_path, Does.Exist);
@@ -490,7 +496,7 @@ namespace TestHelper.Monkey
             [LoadScene(TestScene)]
             public void GetLotteryEntriesWithoutVerbose_NotOutputLog()
             {
-                var lotteryEntries = Monkey.GetLotteryEntries(_interactiveComponentCollector);
+                var lotteryEntries = Monkey.GetLotteryEntries(_interactiveComponentCollector, DefaultIgnoreStrategy.IsIgnored);
                 Assume.That(lotteryEntries.Count, Is.GreaterThan(0));
 
                 LogAssert.NoUnexpectedReceived();
@@ -503,7 +509,7 @@ namespace TestHelper.Monkey
                 GameObject.Find("UsingOnPointerClickHandler").AddComponent<IgnoreAnnotation>();
 
                 var spyLogger = new SpyLogger();
-                var lotteryEntries = Monkey.GetLotteryEntries(_interactiveComponentCollector, verboseLogger: spyLogger);
+                var lotteryEntries = Monkey.GetLotteryEntries(_interactiveComponentCollector, DefaultIgnoreStrategy.IsIgnored, verboseLogger: spyLogger);
                 Assume.That(lotteryEntries.Count, Is.GreaterThan(0));
 
                 Assert.That(spyLogger.Messages.Count, Is.EqualTo(1));
@@ -522,7 +528,7 @@ namespace TestHelper.Monkey
             public void GetLotteryEntriesWithVerbose_NoInteractableObject_LogNoLotteryEntries()
             {
                 var spyLogger = new SpyLogger();
-                var lotteryEntries = Monkey.GetLotteryEntries(_interactiveComponentCollector, verboseLogger: spyLogger);
+                var lotteryEntries = Monkey.GetLotteryEntries(_interactiveComponentCollector, DefaultIgnoreStrategy.IsIgnored, verboseLogger: spyLogger);
                 Assume.That(lotteryEntries, Is.Empty);
 
                 Assert.That(spyLogger.Messages.Count, Is.EqualTo(1));
@@ -534,7 +540,7 @@ namespace TestHelper.Monkey
             public void LotteryOperatorWithVerbose_NotReachableComponentOnly_LogNoLotteryEntries()
             {
                 var spyLogger = new SpyLogger();
-                var lotteryEntries = Monkey.GetLotteryEntries(_interactiveComponentCollector).ToList();
+                var lotteryEntries = Monkey.GetLotteryEntries(_interactiveComponentCollector, DefaultIgnoreStrategy.IsIgnored).ToList();
                 var random = new RandomWrapper();
                 Monkey.LotteryOperator(lotteryEntries, random, DefaultReachableStrategy.IsReachable, spyLogger);
 


### PR DESCRIPTION
### Before
Ignored GameObject check rule is implemented inside Monkey.
It can only check if a GameObject has an `IgnoreAnnotation` component.

### After
Ignored GameObject check rule is pluggable.
Users can implement any IsIgnored function.