### PR TITLE
Fix to exclude component if disabled

### DIFF
--- a/Runtime/DefaultStrategies/DefaultComponentInteractableStrategy.cs
+++ b/Runtime/DefaultStrategies/DefaultComponentInteractableStrategy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Linq;
@@ -27,6 +27,11 @@ namespace TestHelper.Monkey.DefaultStrategies
         /// <returns>True if this Component is interactable</returns>
         public static bool IsInteractable(Component component)
         {
+            if (component == null || (component is Behaviour behaviour && !behaviour.isActiveAndEnabled))
+            {
+                return false;
+            }
+
             // UI element
             var selectable = component as Selectable;
             if (selectable)

--- a/Runtime/DefaultStrategies/DefaultIgnoreStrategy.cs
+++ b/Runtime/DefaultStrategies/DefaultIgnoreStrategy.cs
@@ -2,6 +2,7 @@
 // This software is released under the MIT License.
 
 using TestHelper.Monkey.Annotations;
+using TestHelper.Monkey.Extensions;
 using UnityEngine;
 
 namespace TestHelper.Monkey.DefaultStrategies
@@ -20,7 +21,7 @@ namespace TestHelper.Monkey.DefaultStrategies
         /// <returns>True if GameObject is ignored</returns>
         public static bool IsIgnored(GameObject gameObject, ILogger verboseLogger = null)
         {
-            var hasIgnoreAnnotation = gameObject.TryGetComponent(typeof(IgnoreAnnotation), out _);
+            var hasIgnoreAnnotation = gameObject.TryGetEnabledComponent<IgnoreAnnotation>(out _);
             if (hasIgnoreAnnotation && verboseLogger != null)
             {
                 verboseLogger.Log($"Ignored {gameObject.name}({gameObject.GetInstanceID()}).");

--- a/Runtime/DefaultStrategies/DefaultScreenPointStrategy.cs
+++ b/Runtime/DefaultStrategies/DefaultScreenPointStrategy.cs
@@ -1,7 +1,8 @@
-// Copyright (c) 2023 Koji Hasegawa.
+// Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using TestHelper.Monkey.Annotations;
+using TestHelper.Monkey.Extensions;
 using UnityEngine;
 
 namespace TestHelper.Monkey.DefaultStrategies
@@ -34,12 +35,12 @@ namespace TestHelper.Monkey.DefaultStrategies
         /// <returns>The screen point where monkey operators operate on</returns>
         public static Vector2 GetScreenPoint(GameObject gameObject)
         {
-            if (gameObject.TryGetComponent<ScreenPositionAnnotation>(out var screenPositionAnnotation))
+            if (gameObject.TryGetEnabledComponent<ScreenPositionAnnotation>(out var screenPositionAnnotation))
             {
                 return screenPositionAnnotation.position;
             }
 
-            if (gameObject.TryGetComponent<WorldPositionAnnotation>(out var worldPositionAnnotation))
+            if (gameObject.TryGetEnabledComponent<WorldPositionAnnotation>(out var worldPositionAnnotation))
             {
                 return TransformPositionStrategy.GetScreenPointByWorldPosition(
                     gameObject,
@@ -47,12 +48,12 @@ namespace TestHelper.Monkey.DefaultStrategies
                 );
             }
 
-            if (gameObject.TryGetComponent<ScreenOffsetAnnotation>(out var screenOffsetAnnotation))
+            if (gameObject.TryGetEnabledComponent<ScreenOffsetAnnotation>(out var screenOffsetAnnotation))
             {
                 return TransformPositionStrategy.GetScreenPoint(gameObject) + screenOffsetAnnotation.offset;
             }
 
-            if (gameObject.TryGetComponent<WorldOffsetAnnotation>(out var worldOffsetAnnotation))
+            if (gameObject.TryGetEnabledComponent<WorldOffsetAnnotation>(out var worldOffsetAnnotation))
             {
                 return TransformPositionStrategy.GetScreenPointByWorldPosition(
                     gameObject,

--- a/Runtime/Extensions/GameObjectExtensions.cs
+++ b/Runtime/Extensions/GameObjectExtensions.cs
@@ -169,7 +169,7 @@ namespace TestHelper.Monkey.Extensions
         public static bool TryGetEnabledComponent<T>(this GameObject gameObject, out T component)
         {
             component = gameObject.GetComponent<T>();
-            return component != null && (component is not Behaviour behaviour || behaviour.isActiveAndEnabled);
+            return component != null && (!(component is Behaviour) || (component as Behaviour).isActiveAndEnabled);
         }
     }
 }

--- a/Runtime/Extensions/GameObjectExtensions.cs
+++ b/Runtime/Extensions/GameObjectExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Koji Hasegawa.
+// Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -157,6 +157,19 @@ namespace TestHelper.Monkey.Extensions
         public static bool IsInteractable(this GameObject gameObject)
         {
             return gameObject.GetComponents<MonoBehaviour>().Any(x => x.IsInteractable());
+        }
+
+        /// <summary>
+        /// Try to get a component exclude disabled component.
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <param name="component">A component of the matching type, if found.</param>
+        /// <typeparam name="T">The type of Component to search for</typeparam>
+        /// <returns>True if found and active and enabled component</returns>
+        public static bool TryGetEnabledComponent<T>(this GameObject gameObject, out T component)
+        {
+            component = gameObject.GetComponent<T>();
+            return component != null && (component is not Behaviour behaviour || behaviour.isActiveAndEnabled);
         }
     }
 }

--- a/Runtime/Operators/UGUITextInputOperator.cs
+++ b/Runtime/Operators/UGUITextInputOperator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using TestHelper.Monkey.Annotations;
+using TestHelper.Monkey.Extensions;
 using TestHelper.Monkey.Random;
 using TestHelper.Random;
 using UnityEngine;
@@ -57,8 +58,7 @@ namespace TestHelper.Monkey.Operators
             }
 
             Func<GameObject, RandomStringParameters> randomStringParams;
-            var annotation = component.gameObject.GetComponent<InputFieldAnnotation>();
-            if (annotation != null)
+            if (component.gameObject.TryGetEnabledComponent<InputFieldAnnotation>(out var annotation))
             {
                 // Overwrite rule if annotation is attached.
                 randomStringParams = _ => new RandomStringParameters(

--- a/Tests/Runtime/Annotations/InputFieldAnnotationTest.cs
+++ b/Tests/Runtime/Annotations/InputFieldAnnotationTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Koji Hasegawa.
+// Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -6,8 +6,10 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
 using TestHelper.Monkey.Annotations.Enums;
+using TestHelper.Monkey.Operators;
 using TestHelper.Monkey.TestDoubles;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace TestHelper.Monkey.Annotations
 {
@@ -16,26 +18,31 @@ namespace TestHelper.Monkey.Annotations
     {
         private const string TestScene = "Packages/com.nowsprinting.test-helper.monkey/Tests/Scenes/InputFields.unity";
         private GameObject _annotationAttachedGameObject;
+        private MonkeyConfig _config;
 
         [SetUp]
         public void SetUp()
         {
-            var defaultTextValidator = GameObject.Find("InputField").AddComponent<SpyInputFieldValidator>();
-            defaultTextValidator.SetValidPattern("^[a-zA-Z0-9]{5,10}$");
-
             _annotationAttachedGameObject = GameObject.Find("InputFieldWithAnnotation");
+
+            _config = new MonkeyConfig
+            {
+                Lifetime = TimeSpan.FromMilliseconds(500), // 500ms
+                DelayMillis = 1, // 1ms
+                Operators = new[] { new UGUITextInputOperator() }
+            };
         }
 
         [Test]
         [LoadScene(TestScene)]
-        public async Task DefaultRandomStringParameterOnly()
+        public async Task DefaultRandomStringParameter_Alphanumeric5to10()
         {
-            var config = new MonkeyConfig
-            {
-                Lifetime = TimeSpan.FromMilliseconds(500), // 500ms
-                DelayMillis = 1, // 1ms
-            };
-            await Monkey.Run(config); // as successful if no LogError output
+            var validator = _annotationAttachedGameObject.AddComponent<SpyInputFieldValidator>();
+            validator.SetValidPattern("^[a-zA-Z0-9]{5,10}$");
+
+            await Monkey.Run(_config); // as successful if no LogError output
+
+            Object.Destroy(validator); // teardown
         }
 
         [Test]
@@ -50,32 +57,44 @@ namespace TestHelper.Monkey.Annotations
             var validator = _annotationAttachedGameObject.AddComponent<SpyInputFieldValidator>();
             validator.SetValidPattern("^[0-9]{6,9}$");
 
-            var config = new MonkeyConfig
-            {
-                Lifetime = TimeSpan.FromMilliseconds(500), // 500ms
-                DelayMillis = 1, // 1ms
-            };
-            await Monkey.Run(config); // as successful if no LogError output
+            await Monkey.Run(_config); // as successful if no LogError output
+
+            Object.Destroy(validator); // teardown
         }
 
         [Test]
         [LoadScene(TestScene)]
-        public async Task AttachInputFieldAnnotation_Printable4to11()
+        public async Task AttachInputFieldAnnotation_Printable6to9()
+        {
+            var annotation = _annotationAttachedGameObject.GetComponent<InputFieldAnnotation>();
+            annotation.charactersKind = CharactersKind.Printable;
+            annotation.minimumLength = 6;
+            annotation.maximumLength = 9;
+
+            var validator = _annotationAttachedGameObject.AddComponent<SpyInputFieldValidator>();
+            validator.SetValidPattern("^.{6,9}$");
+
+            await Monkey.Run(_config); // as successful if no LogError output
+
+            Object.Destroy(validator); // teardown
+        }
+
+        [Test]
+        [LoadScene(TestScene)]
+        public async Task DisabledAnnotation_IgnoreAnnotation()
         {
             var annotation = _annotationAttachedGameObject.GetComponent<InputFieldAnnotation>();
             annotation.charactersKind = CharactersKind.Printable;
             annotation.minimumLength = 4;
             annotation.maximumLength = 11;
+            annotation.enabled = false; // disabled
 
             var validator = _annotationAttachedGameObject.AddComponent<SpyInputFieldValidator>();
-            validator.SetValidPattern("^.{4,11}$");
+            validator.SetValidPattern("^[a-zA-Z0-9]{5,10}$"); // respect default parameters
 
-            var config = new MonkeyConfig
-            {
-                Lifetime = TimeSpan.FromMilliseconds(500), // 500ms
-                DelayMillis = 1, // 1ms
-            };
-            await Monkey.Run(config); // as successful if no LogError output
+            await Monkey.Run(_config); // as successful if no LogError output
+
+            Object.Destroy(validator); // teardown
         }
     }
 }

--- a/Tests/Runtime/Annotations/PositionAnnotationTest.cs
+++ b/Tests/Runtime/Annotations/PositionAnnotationTest.cs
@@ -1,21 +1,22 @@
-// Copyright (c) 2023 Koji Hasegawa.
+// Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Linq;
 using NUnit.Framework;
 using TestHelper.Attributes;
 using TestHelper.Monkey.DefaultStrategies;
+using UnityEngine;
 
 namespace TestHelper.Monkey.Annotations
 {
     [TestFixture]
     public class PositionAnnotationTest
     {
-        private const string TestScene = "Packages/com.nowsprinting.test-helper.monkey/Tests/Scenes/PositionAnnotations.unity";
+        private const string TestScene = "../../Scenes/PositionAnnotations.unity";
 
         [Test]
         [LoadScene(TestScene)]
-        public void IsReallyInteractive(
+        public void AttachAnnotation_CorrectedToBeReachable(
             [Values(
                 "WorldOffsetAnnotation",
                 "ScreenOffsetAnnotation",
@@ -25,14 +26,31 @@ namespace TestHelper.Monkey.Annotations
             string name
         )
         {
-            var target = new InteractableComponentsFinder()
-                .FindInteractableComponents()
-                .First(x => x.gameObject.name == name);
+            var target = GameObject.Find(name);
 
-            // Without no position annotations, IsReallyInteractiveFromUser() is always false because
-            // gameObject.transform.position is not in the mesh. So IsReallyInteractiveFromUser() is true means
+            // Without no position annotations, IsReachable() is always false because
+            // gameObject.transform.position is not in the mesh. So IsReachable() is true means
             // the position annotation work well
-            Assert.That(DefaultReachableStrategy.IsReachable(target.gameObject), Is.True);
+            Assert.That(DefaultReachableStrategy.IsReachable(target), Is.True);
+        }
+
+        [Test]
+        [LoadScene(TestScene)]
+        public void DisabledAnnotation_NotReachable(
+            [Values(
+                "WorldOffsetAnnotation",
+                "ScreenOffsetAnnotation",
+                "WorldPositionAnnotation",
+                "ScreenPositionAnnotation"
+            )]
+            string name
+        )
+        {
+            var target = GameObject.Find(name);
+            var annotation = target.GetComponents<MonoBehaviour>().First(x => x.GetType().Name.Equals(name));
+            annotation.enabled = false;
+
+            Assert.That(DefaultReachableStrategy.IsReachable(target), Is.False);
         }
     }
 }

--- a/Tests/Runtime/DefaultStrategies/DefaultComponentInteractableStrategyTest.cs
+++ b/Tests/Runtime/DefaultStrategies/DefaultComponentInteractableStrategyTest.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2023-2025 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using NUnit.Framework;
+using TestHelper.Monkey.TestDoubles;
+using UnityEngine;
+
+namespace TestHelper.Monkey.DefaultStrategies
+{
+    [TestFixture]
+    public class DefaultComponentInteractableStrategyTest
+    {
+        private const string TestScene = "../../Scenes/PhysicsRaycasterSandbox.unity";
+
+        [Test]
+        public void IsInteractable_NotInteractableComponent_ReturnsFalse()
+        {
+            var component = new GameObject().AddComponent<MeshCollider>();
+            Assert.That(DefaultComponentInteractableStrategy.IsInteractable(component), Is.False);
+        }
+
+        [Test]
+        public void IsInteractable_InteractableComponent_ReturnsTrue()
+        {
+            var component = new GameObject().AddComponent<SpyOnPointerClickHandler>();
+            Assert.That(DefaultComponentInteractableStrategy.IsInteractable(component), Is.True);
+        }
+
+        [Test]
+        public void IsInteractable_DisabledInteractableComponent_ReturnsFalse()
+        {
+            var component = new GameObject().AddComponent<SpyOnPointerClickHandler>();
+            component.enabled = false;
+
+            Assert.That(DefaultComponentInteractableStrategy.IsInteractable(component), Is.False);
+        }
+    }
+}

--- a/Tests/Runtime/DefaultStrategies/DefaultComponentInteractableStrategyTest.cs.meta
+++ b/Tests/Runtime/DefaultStrategies/DefaultComponentInteractableStrategyTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 75fcd96ea17b405aa809d6592b0ec47e
+timeCreated: 1739751878

--- a/Tests/Runtime/DefaultStrategies/DefaultIgnoreStrategyTest.cs
+++ b/Tests/Runtime/DefaultStrategies/DefaultIgnoreStrategyTest.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2023-2025 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using NUnit.Framework;
+using TestHelper.Attributes;
+using TestHelper.Monkey.Annotations;
+using UnityEngine;
+
+namespace TestHelper.Monkey.DefaultStrategies
+{
+    [TestFixture]
+    public class DefaultIgnoreStrategyTest
+    {
+        private const string TestScene = "../../Scenes/PhysicsRaycasterSandbox.unity";
+
+        [Test]
+        [LoadScene(TestScene)]
+        public void IsIgnore_WithAnnotation_Ignored()
+        {
+            var cube = GameObject.Find("Cube");
+            cube.AddComponent<IgnoreAnnotation>();
+
+            Assert.That(DefaultIgnoreStrategy.IsIgnored(cube), Is.True);
+        }
+
+        [Test]
+        [LoadScene(TestScene)]
+        public void IsIgnore_WithDisabledAnnotation_NotIgnored()
+        {
+            var cube = GameObject.Find("Cube");
+            var annotation = cube.AddComponent<IgnoreAnnotation>();
+            annotation.enabled = false;
+
+            Assert.That(DefaultIgnoreStrategy.IsIgnored(cube), Is.False);
+        }
+
+        [Test]
+        [LoadScene(TestScene)]
+        public void IsIgnore_WithoutAnnotation_NotIgnored()
+        {
+            var cube = GameObject.Find("Cube");
+            Assert.That(DefaultIgnoreStrategy.IsIgnored(cube), Is.False);
+        }
+    }
+}

--- a/Tests/Runtime/DefaultStrategies/DefaultIgnoreStrategyTest.cs
+++ b/Tests/Runtime/DefaultStrategies/DefaultIgnoreStrategyTest.cs
@@ -15,7 +15,7 @@ namespace TestHelper.Monkey.DefaultStrategies
 
         [Test]
         [LoadScene(TestScene)]
-        public void IsIgnore_WithAnnotation_Ignored()
+        public void IsIgnored_WithAnnotation_Ignored()
         {
             var cube = GameObject.Find("Cube");
             cube.AddComponent<IgnoreAnnotation>();
@@ -25,7 +25,7 @@ namespace TestHelper.Monkey.DefaultStrategies
 
         [Test]
         [LoadScene(TestScene)]
-        public void IsIgnore_WithDisabledAnnotation_NotIgnored()
+        public void IsIgnored_WithDisabledAnnotation_NotIgnored()
         {
             var cube = GameObject.Find("Cube");
             var annotation = cube.AddComponent<IgnoreAnnotation>();
@@ -36,7 +36,7 @@ namespace TestHelper.Monkey.DefaultStrategies
 
         [Test]
         [LoadScene(TestScene)]
-        public void IsIgnore_WithoutAnnotation_NotIgnored()
+        public void IsIgnored_WithoutAnnotation_NotIgnored()
         {
             var cube = GameObject.Find("Cube");
             Assert.That(DefaultIgnoreStrategy.IsIgnored(cube), Is.False);

--- a/Tests/Runtime/DefaultStrategies/DefaultIgnoreStrategyTest.cs.meta
+++ b/Tests/Runtime/DefaultStrategies/DefaultIgnoreStrategyTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ec0234b8f1f74d6f9236ed0e335107d6
+timeCreated: 1739710228


### PR DESCRIPTION
### Fix default strategies
- Fix to ignore disabled interactable components in `DefaultComponentInteractableStrategy`
- Fix to ignore disabled `IgnoreAnnotation`
- Fix to ignore disabled `InputFieldAnnotation`
- Fix to ignore disabled PositionAnnotations
