### PR TITLE
Fix to respect CanvasScaler

### DIFF
--- a/Annotations/ScreenOffsetAnnotation.cs
+++ b/Annotations/ScreenOffsetAnnotation.cs
@@ -6,13 +6,13 @@ using UnityEngine;
 namespace TestHelper.Monkey.Annotations
 {
     /// <summary>
-    /// An annotation class that indicate the screen position offset on screen space that where monkey operators operate
-    /// on
+    /// An annotation class that indicates the screen position offset where monkey operators operate.
     /// </summary>
     public sealed class ScreenOffsetAnnotation : MonoBehaviour
     {
         /// <summary>
-        /// Offset from a screen point of the GameObject that the annotation attached to
+        /// Offset from a screen position of the <c>GameObject</c> that the annotation is attached to.
+        /// Respects <c>CanvasScaler</c> but does not calculate the aspect ratio.
         /// </summary>
         [SerializeField]
         public Vector2 offset;

--- a/Annotations/ScreenPositionAnnotation.cs
+++ b/Annotations/ScreenPositionAnnotation.cs
@@ -11,7 +11,7 @@ namespace TestHelper.Monkey.Annotations
     public sealed class ScreenPositionAnnotation : MonoBehaviour
     {
         /// <summary>
-        /// A screen position that where monkey operators operate on.
+        /// A screen position where monkey operators operate.
         /// It respects <c>CanvasScaler</c> but does not calculate the aspect ratio.
         /// </summary>
         [SerializeField]

--- a/Annotations/ScreenPositionAnnotation.cs
+++ b/Annotations/ScreenPositionAnnotation.cs
@@ -6,12 +6,13 @@ using UnityEngine;
 namespace TestHelper.Monkey.Annotations
 {
     /// <summary>
-    /// An annotation class that indicate the screen position that where monkey operators operate on
+    /// An annotation class that indicates the screen position where monkey operators operate.
     /// </summary>
     public sealed class ScreenPositionAnnotation : MonoBehaviour
     {
         /// <summary>
-        /// A screen position that where monkey operators operate on
+        /// A screen position that where monkey operators operate on.
+        /// It respects <c>CanvasScaler</c> but does not calculate the aspect ratio.
         /// </summary>
         [SerializeField]
         public Vector2 position;

--- a/README.md
+++ b/README.md
@@ -91,21 +91,21 @@ Specify the character kind and length input into `InputField` with `InputFieldAn
 
 ##### ScreenOffsetAnnotation
 
-Specify the screen position offset where Monkey operators operates.
+Specify the screen position offset where Monkey operators operate.
 Respects `CanvasScaler` but does not calculate the aspect ratio.
 
 ##### ScreenPositionAnnotation
 
-Specify the screen position where Monkey operators operates.
+Specify the screen position where Monkey operators operate.
 Respects `CanvasScaler` but does not calculate the aspect ratio.
 
 ##### WorldOffsetAnnotation
 
-Specify the world position offset where Monkey operators operates.
+Specify the world position offset where Monkey operators operate.
 
 ##### WorldPositionAnnotation
 
-Specify the world position where Monkey operators operates.
+Specify the world position where Monkey operators operate.
 
 
 

--- a/README.md
+++ b/README.md
@@ -91,19 +91,21 @@ Specify the character kind and length input into `InputField` with `InputFieldAn
 
 ##### ScreenOffsetAnnotation
 
-Specify the screen position offset on the screen space where Monkey operates.
+Specify the screen position offset where Monkey operators operates.
+Respects `CanvasScaler` but does not calculate the aspect ratio.
 
 ##### ScreenPositionAnnotation
 
-Specify the screen position where Monkey operates.
+Specify the screen position where Monkey operators operates.
+Respects `CanvasScaler` but does not calculate the aspect ratio.
 
 ##### WorldOffsetAnnotation
 
-Specify the screen position offset on world space where Monkey operates.
+Specify the world position offset where Monkey operators operates.
 
 ##### WorldPositionAnnotation
 
-Specify the world position where Monkey operates.
+Specify the world position where Monkey operators operates.
 
 
 

--- a/Runtime/DefaultStrategies/DefaultScreenPointStrategy.cs
+++ b/Runtime/DefaultStrategies/DefaultScreenPointStrategy.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System.Linq;
 using TestHelper.Monkey.Annotations;
 using TestHelper.Monkey.Extensions;
 using UnityEngine;
@@ -37,7 +38,7 @@ namespace TestHelper.Monkey.DefaultStrategies
         {
             if (gameObject.TryGetEnabledComponent<ScreenPositionAnnotation>(out var screenPositionAnnotation))
             {
-                return screenPositionAnnotation.position;
+                return screenPositionAnnotation.position * GetCanvasScale(gameObject);
             }
 
             if (gameObject.TryGetEnabledComponent<WorldPositionAnnotation>(out var worldPositionAnnotation))
@@ -50,7 +51,8 @@ namespace TestHelper.Monkey.DefaultStrategies
 
             if (gameObject.TryGetEnabledComponent<ScreenOffsetAnnotation>(out var screenOffsetAnnotation))
             {
-                return TransformPositionStrategy.GetScreenPoint(gameObject) + screenOffsetAnnotation.offset;
+                return TransformPositionStrategy.GetScreenPoint(gameObject) +
+                       screenOffsetAnnotation.offset * GetCanvasScale(gameObject);
             }
 
             if (gameObject.TryGetEnabledComponent<WorldOffsetAnnotation>(out var worldOffsetAnnotation))
@@ -62,6 +64,12 @@ namespace TestHelper.Monkey.DefaultStrategies
             }
 
             return TransformPositionStrategy.GetScreenPoint(gameObject);
+        }
+
+        private static float GetCanvasScale(GameObject gameObject)
+        {
+            var canvas = gameObject.GetComponentsInParent<Canvas>().FirstOrDefault(x => x.isRootCanvas);
+            return canvas == null ? 1f : canvas.scaleFactor;
         }
     }
 }

--- a/Tests/Runtime/Annotations/PositionAnnotationTest.cs
+++ b/Tests/Runtime/Annotations/PositionAnnotationTest.cs
@@ -1,7 +1,11 @@
 // Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+using JetBrains.Annotations;
 using NUnit.Framework;
 using TestHelper.Attributes;
 using TestHelper.Monkey.DefaultStrategies;
@@ -12,45 +16,65 @@ namespace TestHelper.Monkey.Annotations
     [TestFixture]
     public class PositionAnnotationTest
     {
-        private const string TestScene = "../../Scenes/PositionAnnotations.unity";
-
-        [Test]
-        [LoadScene(TestScene)]
-        public void AttachAnnotation_CorrectedToBeReachable(
-            [Values(
-                "WorldOffsetAnnotation",
-                "ScreenOffsetAnnotation",
-                "WorldPositionAnnotation",
-                "ScreenPositionAnnotation"
-            )]
-            string name
-        )
+        [TestFixture]
+        public class NotOnScaledCanvas
         {
-            var target = GameObject.Find(name);
+            private const string TestScene = "../../Scenes/PositionAnnotations.unity";
 
-            // Without no position annotations, IsReachable() is always false because
-            // gameObject.transform.position is not in the mesh. So IsReachable() is true means
-            // the position annotation work well
-            Assert.That(DefaultReachableStrategy.IsReachable(target), Is.True);
+            private static readonly IEnumerable<string> s_annotations = new[]
+            {
+                "ScreenOffsetAnnotation", "ScreenPositionAnnotation", "WorldOffsetAnnotation",
+                "WorldPositionAnnotation",
+            };
+
+            [TestCaseSource(nameof(s_annotations))]
+            [LoadScene(TestScene)]
+            public void AttachAnnotation_CorrectedToBeReachable(string name)
+            {
+                var target = GameObject.Find(name);
+
+                // Without no position annotations, IsReachable() is always false because
+                // gameObject.transform.position is not in the mesh. So IsReachable() is true means
+                // the position annotation work well
+                Assert.That(DefaultReachableStrategy.IsReachable(target), Is.True);
+            }
+
+            [TestCaseSource(nameof(s_annotations))]
+            [LoadScene(TestScene)]
+            public void DisabledAnnotation_NotReachable(string name)
+            {
+                var target = GameObject.Find(name);
+                var annotation = target.GetComponents<MonoBehaviour>().First(x => x.GetType().Name.Equals(name));
+                annotation.enabled = false;
+
+                Assert.That(DefaultReachableStrategy.IsReachable(target), Is.False);
+            }
         }
 
-        [Test]
-        [LoadScene(TestScene)]
-        public void DisabledAnnotation_NotReachable(
-            [Values(
-                "WorldOffsetAnnotation",
-                "ScreenOffsetAnnotation",
-                "WorldPositionAnnotation",
-                "ScreenPositionAnnotation"
-            )]
-            string name
-        )
+        [TestFixture]
+        public class OnScaledCanvas
         {
-            var target = GameObject.Find(name);
-            var annotation = target.GetComponents<MonoBehaviour>().First(x => x.GetType().Name.Equals(name));
-            annotation.enabled = false;
+            private const string TestScene = "../../Scenes/ScaledCanvas.unity";
 
-            Assert.That(DefaultReachableStrategy.IsReachable(target), Is.False);
+            private static readonly IEnumerable<string> s_annotations = new[]
+            {
+                "ScreenOffsetAnnotation", // The offset is within the GameObject's rect on XGA
+                "ScreenPositionAnnotation", // The position is within the GameObject's rect on XGA
+            };
+
+            [TestCaseSource(nameof(s_annotations))]
+            [LoadScene(TestScene)]
+            [CanBeNull]
+            public async Task AttachAnnotation_OnScaledCanvas_CorrectedToBeReachable(string name)
+            {
+                await UniTask.NextFrame();
+                var target = GameObject.Find(name);
+
+                Assert.That(DefaultReachableStrategy.IsReachable(target, verboseLogger: Debug.unityLogger), Is.True);
+                // The offset/position is within the GameObject's rect on XGA display.
+                // If the annotation's properties don't consider CanvasScaler, the specified position will be outside the GameObject's rect on VGA display.
+                // Then IsReachable will return false.
+            }
         }
     }
 }

--- a/Tests/Scenes/ScaledCanvas.unity
+++ b/Tests/Scenes/ScaledCanvas.unity
@@ -1,0 +1,671 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.46169513, g: 0.5124164, b: 0.58993304, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &532081440
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 532081443}
+  - component: {fileID: 532081442}
+  - component: {fileID: 532081441}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &532081441
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 532081440}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &532081442
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 532081440}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &532081443
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 532081440}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1019825317
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1019825319}
+  - component: {fileID: 1019825318}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1019825318
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1019825317}
+  m_Enabled: 1
+  serializedVersion: 11
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1019825319
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1019825317}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1030097874
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1030097875}
+  - component: {fileID: 1030097878}
+  - component: {fileID: 1030097877}
+  - component: {fileID: 1030097876}
+  m_Layer: 5
+  m_Name: ScreenPositionAnnotation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1030097875
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030097874}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1453920684}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -432, y: -369}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1030097876
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030097874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7fba8bfdd564cc4b1eb4e2a7343670b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  position: {x: 150, y: 20}
+--- !u!114 &1030097877
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030097874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: ScreenPositionAnnotation
+--- !u!222 &1030097878
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030097874}
+  m_CullTransparentMesh: 1
+--- !u!1 &1225857406
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1225857407}
+  - component: {fileID: 1225857409}
+  - component: {fileID: 1225857408}
+  - component: {fileID: 1225857410}
+  m_Layer: 5
+  m_Name: ScreenOffsetAnnotation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1225857407
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1225857406}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1453920684}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -432, y: -334}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1225857408
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1225857406}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: ScreenOffsetAnnotation
+--- !u!222 &1225857409
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1225857406}
+  m_CullTransparentMesh: 1
+--- !u!114 &1225857410
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1225857406}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c774f4b70b7e45558bea3744b75edabc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  offset: {x: 70, y: 10}
+--- !u!1 &1453920680
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1453920684}
+  - component: {fileID: 1453920683}
+  - component: {fileID: 1453920682}
+  - component: {fileID: 1453920681}
+  m_Layer: 5
+  m_Name: Canvas XGA
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1453920681
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1453920680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1453920682
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1453920680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1024, y: 768}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1453920683
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1453920680}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1453920684
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1453920680}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1225857407}
+  - {fileID: 1030097875}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &1472832606
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1472832609}
+  - component: {fileID: 1472832608}
+  - component: {fileID: 1472832607}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1472832607
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1472832606}
+  m_Enabled: 1
+--- !u!20 &1472832608
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1472832606}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1472832609
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1472832606}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1472832609}
+  - {fileID: 1019825319}
+  - {fileID: 1453920684}
+  - {fileID: 532081443}

--- a/Tests/Scenes/ScaledCanvas.unity.meta
+++ b/Tests/Scenes/ScaledCanvas.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5c0827cce1acd4121b536fff1aac6c1b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Before

Not respect `CanvasScaler` when attaching `ScreenOffsetAnnotation` and `ScreenPositionAnnotation`

### After

Respect `CanvasScaler` when attaching `ScreenOffsetAnnotation` and `ScreenPositionAnnotation`

### Limitation

Calculation cannot be performed if the aspect ratio of CanvasScaler and the runtime display differ.