### PR TITLE
Add "Copy to Clipboard" context menu on Hierarchy window

### DIFF
--- a/Editor/ContextMenu/CopyToClipboardMenu.cs
+++ b/Editor/ContextMenu/CopyToClipboardMenu.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2023-2025 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using TestHelper.Monkey.Extensions;
+using UnityEditor;
+
+namespace TestHelper.Monkey.Editor.ContextMenu
+{
+    public static class CopyToClipboardMenu
+    {
+        private const string Prefix = "GameObject/Copy to Clipboard/";
+
+        [MenuItem(Prefix + "Hierarchy Path")]
+        private static void CopyHierarchyPathMenuItem()
+        {
+            var selectedTransform = Selection.activeTransform;
+            if (selectedTransform == null)
+            {
+                return;
+            }
+
+            var path = selectedTransform.GetPath();
+            EditorGUIUtility.systemCopyBuffer = path;
+        }
+
+        [MenuItem(Prefix + "Instance ID")]
+        private static void CopyInstanceIdMenuItem()
+        {
+            var selected = Selection.activeGameObject;
+            if (selected == null)
+            {
+                return;
+            }
+
+            EditorGUIUtility.systemCopyBuffer = selected.GetInstanceID().ToString();
+        }
+    }
+}

--- a/Editor/ContextMenu/CopyToClipboardMenu.cs.meta
+++ b/Editor/ContextMenu/CopyToClipboardMenu.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 66ded96defbe4882946a46413c947292
+timeCreated: 1740444722

--- a/README.md
+++ b/README.md
@@ -229,6 +229,18 @@ public class MyIntegrationTest
 
 
 
+### Editor Extensions
+
+#### Copy Hierarchy Path to Clipboard
+
+Select any `GameObject` in the Hierarchy window and right-click to open the context menu, then select **Copy to Clipboard > Hierarchy Path**.
+
+#### Copy Instance ID to Clipboard
+
+Select any `GameObject` in the Hierarchy window and right-click to open the context menu, then select **Copy to Clipboard > Instance ID**.
+
+
+
 ## Customization
 
 ### Functions for the strategy pattern


### PR DESCRIPTION
### Features

#### Copy Hierarchy Path to Clipboard

Select any `GameObject` in the Hierarchy window and right-click to open the context menu, then select **Copy to Clipboard > Hierarchy Path**.

#### Copy Instance ID to Clipboard

Select any `GameObject` in the Hierarchy window and right-click to open the context menu, then select **Copy to Clipboard > Instance ID**.
