### PR TITLE
Change the Operator's operate target from Component to GameObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Specify the world position where Monkey operators operate.
 
 
 
-### Find and operate interactable components API
+### Find and operate interactable components
 
 `GameObjectFinder` is a class that finds `GameObject` by name or path (can specify [glob](https://en.wikipedia.org/wiki/Glob_(programming)) pattern).
 The constructor can specify the timeout seconds.
@@ -197,7 +197,7 @@ public class MyIntegrationTest
         var finder = new GameObjectFinder();
         var result = await finder.FindByNameAsync("StartButton", interactable: true);
 
-        var button = result.GameObject.GetInteractableComponents().First();
+        var button = result.GameObject;
         var clickOperator = button.SelectOperators<IClickOperator>(_operators).First();
         clickOperator.OperateAsync(button, result.RaycastResult);
     }
@@ -284,7 +284,7 @@ A sub-interface of the `IOperator` (e.g., `IClickOperator`) must be implemented 
 An operator must implement the `CanOperate` method to determine whether an operation such as click is possible and the `OperateAsync` method to execute the operation.
 
 > [!IMPORTANT]  
-> Until test-helper.monkey v0.14, the log output was output in the `Monkey` class. However, this has been changed to be output in `OperateAsync`.
+> Until test-helper.monkey v0.14, it took screenshots and output logs in the caller. However, this has been changed to `OperateAsync` responsible.
 
 
 

--- a/Runtime/Extensions/ComponentExtensions.cs
+++ b/Runtime/Extensions/ComponentExtensions.cs
@@ -19,9 +19,10 @@ namespace TestHelper.Monkey.Extensions
         /// <param name="component"></param>
         /// <param name="operators">All available operators in autopilot/tests. Usually defined in <c>MonkeyConfig</c></param>
         /// <returns>Available operators</returns>
+        [Obsolete("Use GameObjectExtensions.SelectOperators instead.")]
         public static IEnumerable<IOperator> SelectOperators(this Component component, IEnumerable<IOperator> operators)
         {
-            return operators.Where(iOperator => iOperator.CanOperate(component));
+            return operators.Where(iOperator => iOperator.CanOperate(component.gameObject));
         }
 
         /// <summary>
@@ -30,10 +31,11 @@ namespace TestHelper.Monkey.Extensions
         /// <param name="component"></param>
         /// <param name="operators">All available operators in autopilot/tests. Usually defined in <c>MonkeyConfig</c></param>
         /// <returns>Available operators</returns>
+        [Obsolete("Use GameObjectExtensions.SelectOperators<T> instead.")]
         public static IEnumerable<T> SelectOperators<T>(this Component component, IEnumerable<IOperator> operators)
             where T : IOperator
         {
-            return operators.OfType<T>().Where(iOperator => iOperator.CanOperate(component));
+            return operators.OfType<T>().Where(iOperator => iOperator.CanOperate(component.gameObject));
         }
 
         /// <summary>

--- a/Runtime/Extensions/GameObjectExtensions.cs
+++ b/Runtime/Extensions/GameObjectExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using TestHelper.Monkey.DefaultStrategies;
+using TestHelper.Monkey.Operators;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.EventSystems;
@@ -170,6 +171,30 @@ namespace TestHelper.Monkey.Extensions
         {
             component = gameObject.GetComponent<T>();
             return component != null && (!(component is Behaviour) || (component as Behaviour).isActiveAndEnabled);
+        }
+
+        /// <summary>
+        /// Returns the operators available to this component.
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <param name="operators">All available operators in autopilot/tests. Usually defined in <c>MonkeyConfig</c></param>
+        /// <returns>Available operators</returns>
+        public static IEnumerable<IOperator> SelectOperators(this GameObject gameObject,
+            IEnumerable<IOperator> operators)
+        {
+            return operators.Where(iOperator => iOperator.CanOperate(gameObject));
+        }
+
+        /// <summary>
+        /// Returns the operators that specify types and are available to this component.
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <param name="operators">All available operators in autopilot/tests. Usually defined in <c>MonkeyConfig</c></param>
+        /// <returns>Available operators</returns>
+        public static IEnumerable<T> SelectOperators<T>(this GameObject gameObject, IEnumerable<IOperator> operators)
+            where T : IOperator
+        {
+            return operators.OfType<T>().Where(iOperator => iOperator.CanOperate(gameObject));
         }
     }
 }

--- a/Runtime/InteractableComponentsFinder.cs
+++ b/Runtime/InteractableComponentsFinder.cs
@@ -68,7 +68,8 @@ namespace TestHelper.Monkey
         /// <returns>Tuple of interactable component and operator</returns>
         public IEnumerable<(Component, IOperator)> FindInteractableComponentsAndOperators()
         {
-            return FindInteractableComponents().SelectMany(x => x.SelectOperators(_operators), (x, o) => (x, o));
+            return FindInteractableComponents()
+                .SelectMany(x => x.gameObject.SelectOperators(_operators), (x, o) => (x, o));
         }
 
         private static IEnumerable<MonoBehaviour> FindMonoBehaviours()

--- a/Runtime/InteractiveComponent.cs
+++ b/Runtime/InteractiveComponent.cs
@@ -161,7 +161,7 @@ namespace TestHelper.Monkey
         /// Click component.
         /// </summary>
         [Obsolete]
-        public void Click() => GetOperatorsByType<IClickOperator>().First().OperateAsync(component, default);
+        public void Click() => GetOperatorsByType<IClickOperator>().First().OperateAsync(component.gameObject, default);
 
         [Obsolete]
         public bool CanTap() => CanClick();
@@ -182,7 +182,7 @@ namespace TestHelper.Monkey
         public async UniTask ClickAndHold(CancellationToken cancellationToken = default)
         {
             var clickAndHoldOperator = GetOperatorsByType<IClickAndHoldOperator>().First();
-            await clickAndHoldOperator.OperateAsync(component, default, null, null, cancellationToken);
+            await clickAndHoldOperator.OperateAsync(component.gameObject, default, null, null, cancellationToken);
         }
 
         [Obsolete]
@@ -203,7 +203,7 @@ namespace TestHelper.Monkey
         /// </summary>
         [Obsolete]
         public void TextInput() => GetOperatorsByType<ITextInputOperator>().First()
-            .OperateAsync(component, default(RaycastResult));
+            .OperateAsync(component.gameObject, default(RaycastResult));
 
         /// <summary>
         /// Input specified text.
@@ -212,7 +212,7 @@ namespace TestHelper.Monkey
         public void TextInput(string text)
         {
             var textInputOperator = GetOperatorsByType<ITextInputOperator>().First();
-            textInputOperator.OperateAsync(component, text);
+            textInputOperator.OperateAsync(component.gameObject, text);
         }
     }
 }

--- a/Runtime/Operators/IOperator.cs
+++ b/Runtime/Operators/IOperator.cs
@@ -19,11 +19,11 @@ namespace TestHelper.Monkey.Operators
     public interface IOperator
     {
         /// <summary>
-        /// Returns if can operate target component this Operator.
+        /// Returns if can operate target <c>GameObject</c> this Operator.
         /// </summary>
-        /// <param name="component">Operation target component</param>
-        /// <returns>True if can operate component this Operator.</returns>
-        bool CanOperate(Component component);
+        /// <param name="gameObject">Operation target <c>GameObject</c></param>
+        /// <returns>True if can operate <c>GameObject</c> this Operator.</returns>
+        bool CanOperate(GameObject gameObject);
 
         /// <summary>
         /// Execute this operator in monkey testing.
@@ -32,12 +32,12 @@ namespace TestHelper.Monkey.Operators
         /// If required parameters for the operation, such as hold time, input text strategy, etc., keep them in instance fields of the implementation class.
         /// If you want to add parameters for execution outside of monkey tests, define a sub-interface (e.g., <c>ITextInputOperator</c>).
         /// </remarks>
-        /// <param name="component">Operation target component</param>
+        /// <param name="gameObject">Operation target <c>GameObject</c></param>
         /// <param name="raycastResult"><c>RaycastResult</c> includes the screen position of the starting operation. Passing <c>default</c> may be OK, depending on the operator implementation.</param>
         /// <param name="logger">Logger set if you need</param>
         /// <param name="screenshotOptions">Take screenshot options set if you need</param>
         /// <param name="cancellationToken">Cancellation token for operation (e.g., click and hold)</param>
-        UniTask OperateAsync(Component component, RaycastResult raycastResult,
+        UniTask OperateAsync(GameObject gameObject, RaycastResult raycastResult,
             ILogger logger = null, ScreenshotOptions screenshotOptions = null,
             CancellationToken cancellationToken = default);
     }

--- a/Runtime/Operators/IOperator.cs
+++ b/Runtime/Operators/IOperator.cs
@@ -36,8 +36,7 @@ namespace TestHelper.Monkey.Operators
         /// <param name="raycastResult"><c>RaycastResult</c> includes the screen position of the starting operation. Passing <c>default</c> may be OK, depending on the operator implementation.</param>
         /// <param name="logger">Logger set if you need</param>
         /// <param name="screenshotOptions">Take screenshot options set if you need</param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
+        /// <param name="cancellationToken">Cancellation token for operation (e.g., click and hold)</param>
         UniTask OperateAsync(Component component, RaycastResult raycastResult,
             ILogger logger = null, ScreenshotOptions screenshotOptions = null,
             CancellationToken cancellationToken = default);

--- a/Runtime/Operators/ITextInputOperator.cs
+++ b/Runtime/Operators/ITextInputOperator.cs
@@ -16,13 +16,13 @@ namespace TestHelper.Monkey.Operators
         /// <summary>
         /// Text input with specified text.
         /// </summary>
-        /// <param name="component">Operation target component</param>
+        /// <param name="gameObject">Operation target <c>GameObject</c></param>
         /// <param name="text">Text to input</param>
         /// <param name="logger">Logger set if you need</param>
         /// <param name="screenshotOptions">Take screenshot options set if you need</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        UniTask OperateAsync(Component component, string text,
+        UniTask OperateAsync(GameObject gameObject, string text,
             ILogger logger = null, ScreenshotOptions screenshotOptions = null,
             CancellationToken cancellationToken = default);
     }

--- a/Runtime/Operators/UGUIClickAndHoldOperator.cs
+++ b/Runtime/Operators/UGUIClickAndHoldOperator.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using TestHelper.Monkey.Extensions;
 using TestHelper.Monkey.Operators.Utils;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -40,7 +41,7 @@ namespace TestHelper.Monkey.Operators
         /// <inheritdoc />
         public bool CanOperate(GameObject gameObject)
         {
-            if (gameObject.TryGetComponent<EventTrigger>(out var eventTrigger))
+            if (gameObject.TryGetEnabledComponent<EventTrigger>(out var eventTrigger))
             {
                 return eventTrigger.triggers.Any(x => x.eventID == EventTriggerType.PointerDown) &&
                        eventTrigger.triggers.Any(x => x.eventID == EventTriggerType.PointerUp);

--- a/Runtime/Operators/UGUIClickAndHoldOperator.cs
+++ b/Runtime/Operators/UGUIClickAndHoldOperator.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
-using System;
 using System.Linq;
 using System.Threading;
 using Cysharp.Threading.Tasks;
@@ -39,38 +38,35 @@ namespace TestHelper.Monkey.Operators
         }
 
         /// <inheritdoc />
-        public bool CanOperate(Component component)
+        public bool CanOperate(GameObject gameObject)
         {
-            if (component as EventTrigger)
+            if (gameObject.TryGetComponent<EventTrigger>(out var eventTrigger))
             {
-                return ((EventTrigger)component).triggers.Any(x => x.eventID == EventTriggerType.PointerDown) &&
-                       ((EventTrigger)component).triggers.Any(x => x.eventID == EventTriggerType.PointerUp);
+                return eventTrigger.triggers.Any(x => x.eventID == EventTriggerType.PointerDown) &&
+                       eventTrigger.triggers.Any(x => x.eventID == EventTriggerType.PointerUp);
             }
 
-            var interfaces = component.GetType().GetInterfaces();
+            var interfaces = gameObject.GetComponents<Component>()
+                .SelectMany(x => x.GetType().GetInterfaces())
+                .ToList();
             return interfaces.Contains(typeof(IPointerDownHandler)) && interfaces.Contains(typeof(IPointerUpHandler));
         }
 
         /// <inheritdoc />
-        public async UniTask OperateAsync(Component component, RaycastResult raycastResult,
+        public async UniTask OperateAsync(GameObject gameObject, RaycastResult raycastResult,
             ILogger logger = null, ScreenshotOptions screenshotOptions = null,
             CancellationToken cancellationToken = default)
         {
-            if (!(component is IPointerDownHandler) || !(component is IPointerUpHandler))
-            {
-                throw new ArgumentException("Component must implement IPointerDownHandler and IPointerUpHandler.");
-            }
-
             logger = logger ?? _logger;
             screenshotOptions = screenshotOptions ?? _screenshotOptions;
 
             // Output log before the operation, after the shown effects
-            var operationLogger = new OperationLogger(component, this, logger, screenshotOptions);
+            var operationLogger = new OperationLogger(gameObject, this, logger, screenshotOptions);
             operationLogger.Properties.Add("position", raycastResult.screenPosition);
             await operationLogger.Log();
 
             // Do operation
-            using (var pointerClickSimulator = new PointerEventSimulator(component.gameObject, raycastResult, logger))
+            using (var pointerClickSimulator = new PointerEventSimulator(gameObject, raycastResult, logger))
             {
                 await pointerClickSimulator.PointerClickAsync(_holdMillis, cancellationToken);
             }

--- a/Runtime/Operators/UGUIClickAndHoldOperator.cs
+++ b/Runtime/Operators/UGUIClickAndHoldOperator.cs
@@ -8,14 +8,13 @@ using Cysharp.Threading.Tasks;
 using TestHelper.Monkey.Operators.Utils;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using UnityEngine.UI;
 
 namespace TestHelper.Monkey.Operators
 {
     /// <summary>
     /// Click and hold operator for Unity UI (uGUI) components.
     /// a.k.a. touch and hold, long press.
-    ///
+    /// <p/>
     /// This operator receives <c>RaycastResult</c>, but passing <c>default</c> may be OK, depending on the component being operated on.
     /// </summary>
     public class UGUIClickAndHoldOperator : IClickAndHoldOperator
@@ -57,60 +56,24 @@ namespace TestHelper.Monkey.Operators
             ILogger logger = null, ScreenshotOptions screenshotOptions = null,
             CancellationToken cancellationToken = default)
         {
-            if (!(component is IPointerDownHandler downHandler) || !(component is IPointerUpHandler upHandler))
+            if (!(component is IPointerDownHandler) || !(component is IPointerUpHandler))
             {
                 throw new ArgumentException("Component must implement IPointerDownHandler and IPointerUpHandler.");
             }
 
+            logger = logger ?? _logger;
+            screenshotOptions = screenshotOptions ?? _screenshotOptions;
+
             // Output log before the operation, after the shown effects
-            var operationLogger = new OperationLogger(component, this, logger ?? _logger,
-                screenshotOptions ?? _screenshotOptions);
+            var operationLogger = new OperationLogger(component, this, logger, screenshotOptions);
             operationLogger.Properties.Add("position", raycastResult.screenPosition);
             await operationLogger.Log();
 
-            // Selected before operation
-            if (component is Selectable)
+            // Do operation
+            using (var pointerClickSimulator = new PointerEventSimulator(component.gameObject, raycastResult, logger))
             {
-                EventSystem.current.SetSelectedGameObject(component.gameObject);
+                await pointerClickSimulator.PointerClickAsync(_holdMillis, cancellationToken);
             }
-
-            // Pointer down
-            var eventData = new PointerEventData(EventSystem.current)
-            {
-                pointerCurrentRaycast = raycastResult,
-                pointerPressRaycast = raycastResult,
-                rawPointerPress = raycastResult.gameObject,
-#if UNITY_2022_3_OR_NEWER
-                displayIndex = raycastResult.displayIndex,
-#endif
-                position = raycastResult.screenPosition,
-                pressPosition = raycastResult.screenPosition,
-                pointerPress = component.gameObject,
-                // Note: pointerClick is not set here because it is not yet clicked
-#if !UNITY_EDITOR && (UNITY_IOS || UNITY_ANDROID)
-                pointerId = 0, // Touchscreen touches go from 0
-#else
-                pointerId = -1, // Mouse left button
-#endif
-                button = PointerEventData.InputButton.Left,
-                clickCount = 0, // Note: not yet clicked
-            };
-            downHandler.OnPointerDown(eventData);
-
-            await UniTask.Delay(TimeSpan.FromMilliseconds(_holdMillis), ignoreTimeScale: true,
-                cancellationToken: cancellationToken);
-
-            if (component == null || CanOperate(component) == false)
-            {
-                return;
-            }
-
-            // Pointer up
-#if UNITY_2020_3_OR_NEWER
-            eventData.pointerClick = component.gameObject;
-#endif
-            eventData.clickCount = 1;
-            upHandler.OnPointerUp(eventData);
         }
     }
 }

--- a/Runtime/Operators/UGUIClickOperator.cs
+++ b/Runtime/Operators/UGUIClickOperator.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using TestHelper.Monkey.Extensions;
 using TestHelper.Monkey.Operators.Utils;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -35,7 +36,7 @@ namespace TestHelper.Monkey.Operators
         /// <inheritdoc />
         public bool CanOperate(GameObject gameObject)
         {
-            if (gameObject.TryGetComponent<EventTrigger>(out var eventTrigger))
+            if (gameObject.TryGetEnabledComponent<EventTrigger>(out var eventTrigger))
             {
                 return eventTrigger.triggers.Any(x => x.eventID == EventTriggerType.PointerClick);
             }

--- a/Runtime/Operators/UGUITextInputOperator.cs
+++ b/Runtime/Operators/UGUITextInputOperator.cs
@@ -54,9 +54,10 @@ namespace TestHelper.Monkey.Operators
         public bool CanOperate(GameObject gameObject)
         {
 #if ENABLE_TMP
-            return gameObject.TryGetComponent<InputField>(out _) || gameObject.TryGetComponent<TMP_InputField>(out _);
+            return gameObject.TryGetEnabledComponent<InputField>(out _) ||
+                   gameObject.TryGetEnabledComponent<TMP_InputField>(out _);
 #else
-            return gameObject.TryGetComponent<InputField>(out _);
+            return gameObject.TryGetEnabledComponent<InputField>(out _);
 #endif
         }
 
@@ -103,12 +104,12 @@ namespace TestHelper.Monkey.Operators
             // Note: OnDeselect event is called by the system when the focus moves to another element, so it is not called in this method.
 
             // Input text
-            if (gameObject.TryGetComponent<InputField>(out var inputField))
+            if (gameObject.TryGetEnabledComponent<InputField>(out var inputField))
             {
                 inputField.text = text;
             }
 #if ENABLE_TMP
-            if (gameObject.TryGetComponent<TMP_InputField>(out var tmpInputField))
+            if (gameObject.TryGetEnabledComponent<TMP_InputField>(out var tmpInputField))
             {
                 tmpInputField.text = text;
             }

--- a/Runtime/Operators/UGUITextInputOperator.cs
+++ b/Runtime/Operators/UGUITextInputOperator.cs
@@ -51,28 +51,23 @@ namespace TestHelper.Monkey.Operators
         }
 
         /// <inheritdoc />
-        public bool CanOperate(Component component)
+        public bool CanOperate(GameObject gameObject)
         {
 #if ENABLE_TMP
-            return component is InputField || component is TMP_InputField;
+            return gameObject.TryGetComponent<InputField>(out _) || gameObject.TryGetComponent<TMP_InputField>(out _);
 #else
-            return component is InputField;
+            return gameObject.TryGetComponent<InputField>(out _);
 #endif
         }
 
         /// <inheritdoc />
         [SuppressMessage("ReSharper", "UnusedParameter.Local")]
-        public async UniTask OperateAsync(Component component, RaycastResult _,
+        public async UniTask OperateAsync(GameObject gameObject, RaycastResult _,
             ILogger logger = null, ScreenshotOptions screenshotOptions = null,
             CancellationToken cancellationToken = default)
         {
-            if (!CanOperate(component))
-            {
-                throw new ArgumentException("Component must be of type InputField or TMP_InputField.");
-            }
-
             Func<GameObject, RandomStringParameters> randomStringParams;
-            if (component.gameObject.TryGetEnabledComponent<InputFieldAnnotation>(out var annotation))
+            if (gameObject.TryGetEnabledComponent<InputFieldAnnotation>(out var annotation))
             {
                 // Overwrite rule if annotation is attached.
                 randomStringParams = __ => new RandomStringParameters(
@@ -85,39 +80,35 @@ namespace TestHelper.Monkey.Operators
                 randomStringParams = _randomStringParams;
             }
 
-            var text = _randomString.Next(randomStringParams(component.gameObject));
-            await OperateAsync(component, text, logger, screenshotOptions, cancellationToken);
+            var text = _randomString.Next(randomStringParams(gameObject));
+            await OperateAsync(gameObject, text, logger, screenshotOptions, cancellationToken);
         }
 
         /// <inheritdoc />
         [SuppressMessage("ReSharper", "ConvertIfStatementToSwitchStatement")]
-        public async UniTask OperateAsync(Component component, string text,
+        public async UniTask OperateAsync(GameObject gameObject, string text,
             ILogger logger = null, ScreenshotOptions screenshotOptions = null,
             CancellationToken cancellationToken = default)
         {
-            if (!CanOperate(component))
-            {
-                throw new ArgumentException("Component must be of type InputField or TMP_InputField.");
-            }
-
             logger = logger ?? _logger;
             screenshotOptions = screenshotOptions ?? _screenshotOptions;
 
             // Output log before the operation, after the shown effects
-            var operationLogger = new OperationLogger(component, this, logger, screenshotOptions);
+            var operationLogger = new OperationLogger(gameObject, this, logger, screenshotOptions);
             operationLogger.Properties.Add("text", $"\"{text}\"");
             await operationLogger.Log();
 
             // Select before input text
-            ExecuteEvents.ExecuteHierarchy(component.gameObject, null, ExecuteEvents.selectHandler);
+            ExecuteEvents.ExecuteHierarchy(gameObject, null, ExecuteEvents.selectHandler);
+            // Note: OnDeselect event is called by the system when the focus moves to another element, so it is not called in this method.
 
             // Input text
-            if (component is InputField inputField)
+            if (gameObject.TryGetComponent<InputField>(out var inputField))
             {
                 inputField.text = text;
             }
 #if ENABLE_TMP
-            if (component is TMP_InputField tmpInputField)
+            if (gameObject.TryGetComponent<TMP_InputField>(out var tmpInputField))
             {
                 tmpInputField.text = text;
             }

--- a/Runtime/Operators/UGUITextInputOperator.cs
+++ b/Runtime/Operators/UGUITextInputOperator.cs
@@ -2,6 +2,7 @@
 // This software is released under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using TestHelper.Monkey.Annotations;
@@ -60,6 +61,7 @@ namespace TestHelper.Monkey.Operators
         }
 
         /// <inheritdoc />
+        [SuppressMessage("ReSharper", "UnusedParameter.Local")]
         public async UniTask OperateAsync(Component component, RaycastResult _,
             ILogger logger = null, ScreenshotOptions screenshotOptions = null,
             CancellationToken cancellationToken = default)
@@ -88,6 +90,7 @@ namespace TestHelper.Monkey.Operators
         }
 
         /// <inheritdoc />
+        [SuppressMessage("ReSharper", "ConvertIfStatementToSwitchStatement")]
         public async UniTask OperateAsync(Component component, string text,
             ILogger logger = null, ScreenshotOptions screenshotOptions = null,
             CancellationToken cancellationToken = default)
@@ -97,14 +100,16 @@ namespace TestHelper.Monkey.Operators
                 throw new ArgumentException("Component must be of type InputField or TMP_InputField.");
             }
 
+            logger = logger ?? _logger;
+            screenshotOptions = screenshotOptions ?? _screenshotOptions;
+
             // Output log before the operation, after the shown effects
-            var operationLogger = new OperationLogger(component, this, logger ?? _logger,
-                screenshotOptions ?? _screenshotOptions);
+            var operationLogger = new OperationLogger(component, this, logger, screenshotOptions);
             operationLogger.Properties.Add("text", $"\"{text}\"");
             await operationLogger.Log();
 
-            // Selected before operation
-            EventSystem.current.SetSelectedGameObject(component.gameObject);
+            // Select before input text
+            ExecuteEvents.ExecuteHierarchy(component.gameObject, null, ExecuteEvents.selectHandler);
 
             // Input text
             if (component is InputField inputField)

--- a/Runtime/Operators/Utils/OperationLogger.cs
+++ b/Runtime/Operators/Utils/OperationLogger.cs
@@ -14,7 +14,7 @@ namespace TestHelper.Monkey.Operators.Utils
     /// </summary>
     public class OperationLogger
     {
-        private readonly Component _component;
+        private readonly GameObject _gameObject;
         private readonly IOperator _operator;
         private readonly ILogger _logger;
         private readonly ScreenshotOptions _screenshotOptions;
@@ -37,14 +37,14 @@ namespace TestHelper.Monkey.Operators.Utils
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="component"></param>
+        /// <param name="gameObject"></param>
         /// <param name="operator"></param>
         /// <param name="logger"></param>
         /// <param name="screenshotOptions"></param>
-        public OperationLogger(Component component, IOperator @operator, ILogger logger,
+        public OperationLogger(GameObject gameObject, IOperator @operator, ILogger logger,
             ScreenshotOptions screenshotOptions = null)
         {
-            _component = component;
+            _gameObject = gameObject;
             _operator = @operator;
             _logger = logger;
             _screenshotOptions = screenshotOptions;
@@ -66,7 +66,7 @@ namespace TestHelper.Monkey.Operators.Utils
                         stereoCaptureMode: _screenshotOptions.StereoCaptureMode,
                         logFilepath: false
                     )
-                    .ToUniTask(_component as MonoBehaviour);
+                    .ToUniTask(_gameObject.GetComponent<MonoBehaviour>());
             }
 
             _logger.Log(BuildMessage());
@@ -75,7 +75,7 @@ namespace TestHelper.Monkey.Operators.Utils
         internal string BuildMessage()
         {
             var builder = new StringBuilder();
-            builder.Append($"{_operator.GetType().Name} operates to {_component.gameObject.name}");
+            builder.Append($"{_operator.GetType().Name} operates to {_gameObject.name}");
 
             if (Comments.Count > 0)
             {
@@ -85,7 +85,7 @@ namespace TestHelper.Monkey.Operators.Utils
             }
             else
             {
-                builder.Append($"({_component.gameObject.GetInstanceID()})");
+                builder.Append($"({_gameObject.GetInstanceID()})");
             }
 
             if (Properties.Count > 0)

--- a/Runtime/Operators/Utils/PointerEventSimulator.cs
+++ b/Runtime/Operators/Utils/PointerEventSimulator.cs
@@ -54,7 +54,7 @@ namespace TestHelper.Monkey.Operators.Utils
         /// </list>
         /// </summary>
         /// <remarks>
-        /// <c>OnDeselect</c> event is called by the system when the focus moves to another element, so it is not called explicitly.
+        /// <c>OnDeselect</c> event is called by the system when the focus moves to another element, so it is not called in this method.
         /// </remarks>
         /// <param name="holdMillis">Hold time in milliseconds if click-and-hold</param>
         /// <param name="cancellationToken">Cancellation token to use when holding</param>

--- a/Runtime/Operators/Utils/PointerEventSimulator.cs
+++ b/Runtime/Operators/Utils/PointerEventSimulator.cs
@@ -1,0 +1,101 @@
+// Copyright (c) 2023-2025 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace TestHelper.Monkey.Operators.Utils
+{
+    /// <summary>
+    /// Simulator class to reproduce pointer events.
+    /// </summary>
+    public sealed class PointerEventSimulator : IDisposable
+    {
+        private readonly GameObject _gameObject;
+        private readonly ILogger _logger;
+        private readonly bool _hasSelectable;
+        private readonly SimulatedPointerEventData _eventData;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="gameObject">Click target <c>GameObject</c></param>
+        /// <param name="raycastResult"><c>RaycastResult</c> includes the screen position of the starting operation. Passing <c>default</c> may be OK, depending on the game-title implementation.</param>
+        /// <param name="logger">Logger set if you need</param>
+        public PointerEventSimulator(GameObject gameObject, RaycastResult raycastResult, ILogger logger = null)
+        {
+            _gameObject = gameObject;
+            _logger = logger;
+            _hasSelectable = gameObject.GetComponent<Selectable>() != null;
+            _eventData = new SimulatedPointerEventData(gameObject, raycastResult);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _eventData.Dispose();
+        }
+
+        /// <summary>
+        /// Reproduce the sequence of events that happen when pointer-clicking.
+        /// <list type="number">
+        ///     <item><c>OnPointerEnter</c></item>
+        ///     <item><c>OnSelect</c> (if <c>Selectable</c> is attached)</item>
+        ///     <item><c>OnPointerDown</c></item>
+        ///     <item><c>OnInitializePotentialDrag</c></item>
+        ///     <item>Wait for the hold time</item>
+        ///     <item><c>OnPointerUp</c></item>
+        ///     <item><c>OnPointerClick</c></item>
+        ///     <item><c>OnPointerExit</c></item>
+        /// </list>
+        /// </summary>
+        /// <remarks>
+        /// <c>OnDeselect</c> event is called by the system when the focus moves to another element, so it is not called explicitly.
+        /// </remarks>
+        /// <param name="holdMillis">Hold time in milliseconds if click-and-hold</param>
+        /// <param name="cancellationToken">Cancellation token to use when holding</param>
+        public async UniTask PointerClickAsync(int holdMillis = 0, CancellationToken cancellationToken = default)
+        {
+            var gameObjectNameCache = _gameObject.name;
+
+            // Enter
+            ExecuteEvents.ExecuteHierarchy(_gameObject, _eventData, ExecuteEvents.pointerEnterHandler);
+            if (_hasSelectable)
+            {
+                ExecuteEvents.ExecuteHierarchy(_gameObject, _eventData, ExecuteEvents.selectHandler);
+            }
+
+            // Down
+            ExecuteEvents.ExecuteHierarchy(_gameObject, _eventData, ExecuteEvents.pointerDownHandler);
+            ExecuteEvents.ExecuteHierarchy(_gameObject, _eventData, ExecuteEvents.initializePotentialDrag);
+
+            if (holdMillis > 0)
+            {
+                await UniTask.Delay(holdMillis, ignoreTimeScale: true, cancellationToken: cancellationToken);
+            }
+            else
+            {
+                await UniTask.NextFrame(cancellationToken: cancellationToken);
+            }
+
+            if (_gameObject == null)
+            {
+                _logger?.Log($"{gameObjectNameCache} is destroyed before pointer-up event.");
+                return;
+            }
+
+            // Up
+            ExecuteEvents.ExecuteHierarchy(_gameObject, _eventData, ExecuteEvents.pointerUpHandler);
+            _eventData.SetStateToClicking();
+            ExecuteEvents.ExecuteHierarchy(_gameObject, _eventData, ExecuteEvents.pointerClickHandler);
+            _eventData.SetStateToClicked();
+
+            // Exit
+            ExecuteEvents.ExecuteHierarchy(_gameObject, _eventData, ExecuteEvents.pointerExitHandler);
+        }
+    }
+}

--- a/Runtime/Operators/Utils/PointerEventSimulator.cs.meta
+++ b/Runtime/Operators/Utils/PointerEventSimulator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0f286755c669451689d7bbdbf0a655dd
+timeCreated: 1740873773

--- a/Runtime/Operators/Utils/SimulatedPointerEventData.cs
+++ b/Runtime/Operators/Utils/SimulatedPointerEventData.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2023-2025 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace TestHelper.Monkey.Operators.Utils
+{
+    /// <summary>
+    /// Class that simulates the pointer-down state of <see cref="PointerEventData"/>.
+    /// </summary>
+    internal sealed class SimulatedPointerEventData : PointerEventData, IDisposable
+    {
+        public enum PointingDeviceType
+        {
+            Auto,
+            Mouse,
+            TouchScreen,
+        }
+
+        private readonly PointingDeviceType _deviceType; // Mouse or TouchScreen
+
+        private static int s_touchCount; // Touchscreen touches go from 0
+
+        /// <summary>
+        /// Constructor for pointer-down state.
+        /// </summary>
+        /// <param name="gameObject">Event target <c>GameObject</c></param>
+        /// <param name="raycastResult"><c>RaycastResult</c> includes the screen position of the starting operation. Passing <c>default</c> may be OK, depending on the game-title implementation.</param>
+        /// <param name="deviceType">Can specify mouse or touch screen for tests</param>
+        public SimulatedPointerEventData(
+            GameObject gameObject,
+            RaycastResult raycastResult,
+            PointingDeviceType deviceType = PointingDeviceType.Auto)
+            : base(EventSystem.current)
+        {
+            // ReSharper disable once ConvertIfStatementToConditionalTernaryExpression
+            if (deviceType == PointingDeviceType.Auto)
+            {
+#if !UNITY_EDITOR && (UNITY_IOS || UNITY_ANDROID)
+                _deviceType = PointingDeviceType.TouchScreen;
+#else
+                _deviceType = PointingDeviceType.Mouse;
+#endif
+            }
+            else
+            {
+                _deviceType = deviceType;
+            }
+
+            // Set the initial state of the pointer-down event based on RaycastResult
+            pointerCurrentRaycast = raycastResult;
+            pointerPressRaycast = raycastResult;
+            rawPointerPress = raycastResult.gameObject;
+#if UNITY_2022_3_OR_NEWER
+            displayIndex = raycastResult.displayIndex;
+#endif
+            position = raycastResult.screenPosition;
+            pressPosition = raycastResult.screenPosition;
+
+            // Set the initial state of the pointer-down event based on target GameObject
+            pointerPress = gameObject;
+
+            if (_deviceType == PointingDeviceType.TouchScreen)
+            {
+                pointerId = s_touchCount++; // Touchscreen touches go from 0
+            }
+            else
+            {
+                pointerId = -1; // Mouse left button
+            }
+
+            button = InputButton.Left;
+            clickCount = 0; // Note: not yet clicked
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (_deviceType == PointingDeviceType.TouchScreen)
+            {
+                s_touchCount--;
+            }
+        }
+
+        /// <summary>
+        /// Transition state to the click state.
+        /// </summary>
+        public void SetStateToClicking()
+        {
+#if UNITY_2020_3_OR_NEWER
+            pointerClick = pointerPress;
+#endif
+            clickCount++;
+        }
+
+        /// <summary>
+        /// Transition state to the click state.
+        /// </summary>
+        public void SetStateToClicked()
+        {
+            clickTime = Time.realtimeSinceStartup;
+        }
+    }
+}

--- a/Runtime/Operators/Utils/SimulatedPointerEventData.cs.meta
+++ b/Runtime/Operators/Utils/SimulatedPointerEventData.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7505d8f4d01f458694f1be2fe8ed95e5
+timeCreated: 1740893775

--- a/Samples~/uGUI Demo/Tests/Runtime/ScenarioTest.cs
+++ b/Samples~/uGUI Demo/Tests/Runtime/ScenarioTest.cs
@@ -29,25 +29,25 @@ namespace TestHelper.Monkey.Samples.UGUIDemo
 
             // When click Start button, then open Home screen.
             var startButton = await _finder.FindByNameAsync("StartButton", interactable: true);
-            var startComponent = startButton.GameObject.GetInteractableComponents().First();
-            var startOperator = startComponent.SelectOperators<IClickOperator>(_config.Operators).First();
-            await startOperator.OperateAsync(startComponent, startButton.RaycastResult);
+            var startButtonObject = startButton.GameObject;
+            var startOperator = startButtonObject.SelectOperators<IClickOperator>(_config.Operators).First();
+            await startOperator.OperateAsync(startButtonObject, startButton.RaycastResult);
 
             await _finder.FindByNameAsync("Home");
 
             // When click target button, then open target screen.
             var targetButton = await _finder.FindByNameAsync($"{target}Button", interactable: true);
-            var targetComponent = targetButton.GameObject.GetInteractableComponents().First();
-            var targetOperator = targetComponent.SelectOperators<IClickOperator>(_config.Operators).First();
-            await targetOperator.OperateAsync(targetComponent, targetButton.RaycastResult);
+            var targetObject = targetButton.GameObject;
+            var targetOperator = targetObject.SelectOperators<IClickOperator>(_config.Operators).First();
+            await targetOperator.OperateAsync(targetObject, targetButton.RaycastResult);
 
             await _finder.FindByNameAsync(target);
 
             // When click Back button, then return Home screen.
             var backButton = await _finder.FindByPathAsync($"**/{target}/BackButton", interactable: true);
-            var backComponent = backButton.GameObject.GetInteractableComponents().First();
-            var backOperator = backComponent.SelectOperators<IClickOperator>(_config.Operators).First();
-            await backOperator.OperateAsync(backComponent, backButton.RaycastResult);
+            var backObject = backButton.GameObject;
+            var backOperator = backObject.SelectOperators<IClickOperator>(_config.Operators).First();
+            await backOperator.OperateAsync(backObject, backButton.RaycastResult);
 
             await _finder.FindByNameAsync("Home");
         }

--- a/Tests/Runtime/InteractiveComponentTest.cs
+++ b/Tests/Runtime/InteractiveComponentTest.cs
@@ -157,19 +157,6 @@ namespace TestHelper.Monkey
             }
 
             [Test]
-            public void Click_InvokeOnClick()
-            {
-                var button = new GameObject().AddComponent<Button>();
-                button.onClick.AddListener(() => Debug.Log("Invoke Button.OnClick!"));
-                var sut = InteractiveComponent.CreateInteractableComponent(button, operators: _operators);
-
-                Assume.That(sut.CanClick(), Is.True);
-                sut.Click();
-
-                LogAssert.Expect(LogType.Log, "Invoke Button.OnClick!");
-            }
-
-            [Test]
             public async Task ClickAndHold_InvokeOnPointerDownAndUp()
             {
                 var button = new GameObject("ClickAndHoldTarget").AddComponent<SpyOnPointerDownUpHandler>();

--- a/Tests/Runtime/Operators/UGUIClickAndHoldOperatorTest.cs
+++ b/Tests/Runtime/Operators/UGUIClickAndHoldOperatorTest.cs
@@ -22,20 +22,22 @@ namespace TestHelper.Monkey.Operators
         [Test]
         public void CanOperate_CanNotTouchAndHold_ReturnFalse()
         {
-            var component = new GameObject().AddComponent<SpyOnPointerClickHandler>();
+            var gameObject = new GameObject();
+            gameObject.AddComponent<SpyOnPointerClickHandler>();
 
-            Assert.That(_sut.CanOperate(component), Is.False);
+            Assert.That(_sut.CanOperate(gameObject), Is.False);
         }
 
         [Test]
         public async Task OperateAsync_EventHandler_InvokeOnPointerDownAndUp()
         {
-            var component = new GameObject("ClickAndHoldTarget").AddComponent<SpyOnPointerDownUpHandler>();
-            var position = TransformPositionStrategy.GetScreenPoint(component.gameObject);
+            var gameObject = new GameObject("ClickAndHoldTarget");
+            gameObject.AddComponent<SpyOnPointerDownUpHandler>();
+            var position = TransformPositionStrategy.GetScreenPoint(gameObject);
             var raycastResult = new RaycastResult { screenPosition = position };
 
-            Assume.That(_sut.CanOperate(component), Is.True);
-            await _sut.OperateAsync(component, raycastResult);
+            Assume.That(_sut.CanOperate(gameObject), Is.True);
+            await _sut.OperateAsync(gameObject, raycastResult);
 
             LogAssert.Expect(LogType.Log, "ClickAndHoldTarget.OnPointerDown");
             LogAssert.Expect(LogType.Log, "ClickAndHoldTarget.OnPointerUp");
@@ -44,13 +46,13 @@ namespace TestHelper.Monkey.Operators
         [Test]
         public async Task OperateAsync_EventTrigger_InvokeOnPointerDownAndUp()
         {
-            var receiver = new GameObject("ClickAndHoldTarget").AddComponent<SpyPointerDownUpEventReceiver>();
-            var component = receiver.gameObject.GetComponent<EventTrigger>();
-            var position = TransformPositionStrategy.GetScreenPoint(component.gameObject);
+            var gameObject = new GameObject("ClickAndHoldTarget");
+            gameObject.AddComponent<SpyPointerDownUpEventReceiver>();
+            var position = TransformPositionStrategy.GetScreenPoint(gameObject);
             var raycastResult = new RaycastResult { screenPosition = position };
 
-            Assume.That(_sut.CanOperate(component), Is.True);
-            await _sut.OperateAsync(component, raycastResult);
+            Assume.That(_sut.CanOperate(gameObject), Is.True);
+            await _sut.OperateAsync(gameObject, raycastResult);
 
             LogAssert.Expect(LogType.Log, "ClickAndHoldTarget.ReceivePointerDown");
             LogAssert.Expect(LogType.Log, "ClickAndHoldTarget.ReceivePointerUp");
@@ -59,12 +61,13 @@ namespace TestHelper.Monkey.Operators
         [Test]
         public async Task OperateAsync_DestroyAfterPointerDown_NoError()
         {
-            var component = new GameObject("ClickAndHoldTarget").AddComponent<StubDestroyingItselfWhenPointerDown>();
-            var position = TransformPositionStrategy.GetScreenPoint(component.gameObject);
+            var gameObject = new GameObject("ClickAndHoldTarget");
+            gameObject.AddComponent<StubDestroyingItselfWhenPointerDown>();
+            var position = TransformPositionStrategy.GetScreenPoint(gameObject);
             var raycastResult = new RaycastResult { screenPosition = position };
 
-            Assume.That(_sut.CanOperate(component), Is.True);
-            await _sut.OperateAsync(component, raycastResult);
+            Assume.That(_sut.CanOperate(gameObject), Is.True);
+            await _sut.OperateAsync(gameObject, raycastResult);
 
             LogAssert.Expect(LogType.Log, "ClickAndHoldTarget.OnPointerDown");
             LogAssert.Expect(LogType.Log, "ClickAndHoldTarget.Destroy");
@@ -74,15 +77,16 @@ namespace TestHelper.Monkey.Operators
         [SuppressMessage("ReSharper", "MethodSupportsCancellation")]
         public async Task OperateAsync_Cancel()
         {
-            var component = new GameObject("ClickAndHoldTarget").AddComponent<StubLogErrorWhenOnPointerUp>();
-            var position = TransformPositionStrategy.GetScreenPoint(component.gameObject);
+            var gameObject = new GameObject("ClickAndHoldTarget");
+            gameObject.AddComponent<StubLogErrorWhenOnPointerUp>();
+            var position = TransformPositionStrategy.GetScreenPoint(gameObject);
             var raycastResult = new RaycastResult { screenPosition = position };
 
-            Assume.That(_sut.CanOperate(component), Is.True);
+            Assume.That(_sut.CanOperate(gameObject), Is.True);
 
             using (var cancellationTokenSource = new CancellationTokenSource())
             {
-                _sut.OperateAsync(component, raycastResult, null, null, cancellationTokenSource.Token).Forget();
+                _sut.OperateAsync(gameObject, raycastResult, null, null, cancellationTokenSource.Token).Forget();
                 await UniTask.NextFrame();
 
                 cancellationTokenSource.Cancel(); // Not output LogError from StubLogErrorWhenOnPointerUp

--- a/Tests/Runtime/Operators/UGUIClickAndHoldOperatorTest.cs
+++ b/Tests/Runtime/Operators/UGUIClickAndHoldOperatorTest.cs
@@ -67,7 +67,7 @@ namespace TestHelper.Monkey.Operators
             await _sut.OperateAsync(component, raycastResult);
 
             LogAssert.Expect(LogType.Log, "ClickAndHoldTarget.OnPointerDown");
-            LogAssert.Expect(LogType.Log, "ClickAndHoldTarget.DestroyImmediate");
+            LogAssert.Expect(LogType.Log, "ClickAndHoldTarget.Destroy");
         }
 
         [Test]

--- a/Tests/Runtime/Operators/UGUIClickOperatorTest.cs
+++ b/Tests/Runtime/Operators/UGUIClickOperatorTest.cs
@@ -19,20 +19,22 @@ namespace TestHelper.Monkey.Operators
         [Test]
         public void CanOperate_CanNotClick_ReturnFalse()
         {
-            var component = new GameObject().AddComponent<SpyOnPointerDownUpHandler>();
+            var gameObject = new GameObject();
+            gameObject.AddComponent<SpyOnPointerDownUpHandler>();
 
-            Assert.That(_sut.CanOperate(component), Is.False);
+            Assert.That(_sut.CanOperate(gameObject), Is.False);
         }
 
         [Test]
         public async Task OperateAsync_EventHandler_InvokeOnClick()
         {
-            var component = new GameObject("ClickTarget").AddComponent<SpyOnPointerClickHandler>();
-            var position = TransformPositionStrategy.GetScreenPoint(component.gameObject);
+            var gameObject = new GameObject("ClickTarget");
+            gameObject.AddComponent<SpyOnPointerClickHandler>();
+            var position = TransformPositionStrategy.GetScreenPoint(gameObject);
             var raycastResult = new RaycastResult { screenPosition = position };
 
-            Assume.That(_sut.CanOperate(component), Is.True);
-            await _sut.OperateAsync(component, raycastResult);
+            Assume.That(_sut.CanOperate(gameObject), Is.True);
+            await _sut.OperateAsync(gameObject, raycastResult);
 
             LogAssert.Expect(LogType.Log, "ClickTarget.OnPointerClick");
         }
@@ -40,13 +42,13 @@ namespace TestHelper.Monkey.Operators
         [Test]
         public async Task OperateAsync_EventTrigger_InvokeOnClick()
         {
-            var receiver = new GameObject("ClickTarget").AddComponent<SpyPointerClickEventReceiver>();
-            var component = receiver.gameObject.GetComponent<EventTrigger>();
-            var position = TransformPositionStrategy.GetScreenPoint(component.gameObject);
+            var gameObject = new GameObject("ClickTarget");
+            gameObject.AddComponent<SpyPointerClickEventReceiver>();
+            var position = TransformPositionStrategy.GetScreenPoint(gameObject);
             var raycastResult = new RaycastResult { screenPosition = position };
 
-            Assume.That(_sut.CanOperate(component), Is.True);
-            await _sut.OperateAsync(component, raycastResult);
+            Assume.That(_sut.CanOperate(gameObject), Is.True);
+            await _sut.OperateAsync(gameObject, raycastResult);
 
             LogAssert.Expect(LogType.Log, "ClickTarget.ReceivePointerClick");
         }

--- a/Tests/Runtime/Operators/UGUIClickOperatorTest.cs
+++ b/Tests/Runtime/Operators/UGUIClickOperatorTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2023-2024 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Monkey.DefaultStrategies;
 using TestHelper.Monkey.TestDoubles;
@@ -24,20 +25,20 @@ namespace TestHelper.Monkey.Operators
         }
 
         [Test]
-        public void OperateAsync_EventHandler_InvokeOnClick()
+        public async Task OperateAsync_EventHandler_InvokeOnClick()
         {
             var component = new GameObject("ClickTarget").AddComponent<SpyOnPointerClickHandler>();
             var position = TransformPositionStrategy.GetScreenPoint(component.gameObject);
             var raycastResult = new RaycastResult { screenPosition = position };
 
             Assume.That(_sut.CanOperate(component), Is.True);
-            _sut.OperateAsync(component, raycastResult);
+            await _sut.OperateAsync(component, raycastResult);
 
             LogAssert.Expect(LogType.Log, "ClickTarget.OnPointerClick");
         }
 
         [Test]
-        public void OperateAsync_EventTrigger_InvokeOnClick()
+        public async Task OperateAsync_EventTrigger_InvokeOnClick()
         {
             var receiver = new GameObject("ClickTarget").AddComponent<SpyPointerClickEventReceiver>();
             var component = receiver.gameObject.GetComponent<EventTrigger>();
@@ -45,7 +46,7 @@ namespace TestHelper.Monkey.Operators
             var raycastResult = new RaycastResult { screenPosition = position };
 
             Assume.That(_sut.CanOperate(component), Is.True);
-            _sut.OperateAsync(component, raycastResult);
+            await _sut.OperateAsync(component, raycastResult);
 
             LogAssert.Expect(LogType.Log, "ClickTarget.ReceivePointerClick");
         }

--- a/Tests/Runtime/Operators/UGUITextInputOperatorTest.cs
+++ b/Tests/Runtime/Operators/UGUITextInputOperatorTest.cs
@@ -24,53 +24,58 @@ namespace TestHelper.Monkey.Operators
         [Test]
         public void CanOperate_NotInputText_ReturnFalse()
         {
-            var component = new GameObject().AddComponent<Button>();
+            var gameObject = new GameObject();
+            gameObject.AddComponent<Button>();
 
-            Assert.That(_sut.CanOperate(component), Is.False);
+            Assert.That(_sut.CanOperate(gameObject), Is.False);
         }
 
         [Test]
         public void OperateAsync_InputText_SetsRandomText()
         {
-            var component = new GameObject().AddComponent<InputField>();
+            var gameObject = new GameObject();
+            var inputField = gameObject.AddComponent<InputField>();
 
-            Assume.That(_sut.CanOperate(component), Is.True);
-            _sut.OperateAsync(component, default(RaycastResult));
+            Assume.That(_sut.CanOperate(gameObject), Is.True);
+            _sut.OperateAsync(gameObject, default(RaycastResult));
 
-            Assert.That(component.text, Is.EqualTo("RANDOM"));
+            Assert.That(inputField.text, Is.EqualTo("RANDOM"));
         }
 
         [Test]
         public void OperateAsync_InputTextWithText_SetsSpecifiedText()
         {
-            var component = new GameObject().AddComponent<InputField>();
+            var gameObject = new GameObject();
+            var inputField = gameObject.AddComponent<InputField>();
 
-            Assume.That(_sut.CanOperate(component), Is.True);
-            _sut.OperateAsync(component, "SPECIFIED");
+            Assume.That(_sut.CanOperate(gameObject), Is.True);
+            _sut.OperateAsync(gameObject, "SPECIFIED");
 
-            Assert.That(component.text, Is.EqualTo("SPECIFIED"));
+            Assert.That(inputField.text, Is.EqualTo("SPECIFIED"));
         }
 
         [Test]
         public void OperateAsync_TmpInputText_SetsRandomText()
         {
-            var component = new GameObject().AddComponent<TMP_InputField>();
+            var gameObject = new GameObject();
+            var inputField = gameObject.AddComponent<TMP_InputField>();
 
-            Assume.That(_sut.CanOperate(component), Is.True);
-            _sut.OperateAsync(component, default(RaycastResult));
+            Assume.That(_sut.CanOperate(gameObject), Is.True);
+            _sut.OperateAsync(gameObject, default(RaycastResult));
 
-            Assert.That(component.text, Is.EqualTo("RANDOM"));
+            Assert.That(inputField.text, Is.EqualTo("RANDOM"));
         }
 
         [Test]
         public void OperateAsync_TmpInputTextWithText_SetsSpecifiedText()
         {
-            var component = new GameObject().AddComponent<TMP_InputField>();
+            var gameObject = new GameObject();
+            var inputField = gameObject.AddComponent<TMP_InputField>();
 
-            Assume.That(_sut.CanOperate(component), Is.True);
-            _sut.OperateAsync(component, "SPECIFIED");
+            Assume.That(_sut.CanOperate(gameObject), Is.True);
+            _sut.OperateAsync(gameObject, "SPECIFIED");
 
-            Assert.That(component.text, Is.EqualTo("SPECIFIED"));
+            Assert.That(inputField.text, Is.EqualTo("SPECIFIED"));
         }
     }
 }

--- a/Tests/Runtime/Operators/Utils/OperationLoggerTest.cs
+++ b/Tests/Runtime/Operators/Utils/OperationLoggerTest.cs
@@ -16,10 +16,11 @@ namespace TestHelper.Monkey.Operators.Utils
 
         private OperationLogger CreateOperationLogger(ScreenshotOptions screenshotOptions = null)
         {
-            var component = new GameObject("Target").AddComponent<FakeComponent>();
+            var gameObject = new GameObject("Target");
+            gameObject.AddComponent<FakeComponent>();
             var @operator = new UGUIClickOperator();
             _spyLogger = new SpyLogger();
-            return new OperationLogger(component, @operator, _spyLogger, screenshotOptions);
+            return new OperationLogger(gameObject, @operator, _spyLogger, screenshotOptions);
         }
 
         [Test]

--- a/Tests/Runtime/Operators/Utils/SimulatedPointerEventDataTest.cs
+++ b/Tests/Runtime/Operators/Utils/SimulatedPointerEventDataTest.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2023-2025 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace TestHelper.Monkey.Operators.Utils
+{
+    [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP017:Prefer using")]
+    public class SimulatedPointerEventDataTest
+    {
+        [Test]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
+        public void Constructor_WithoutPointingDeviceTypeInEditor_AsMouse()
+        {
+            var sut = new SimulatedPointerEventData(null, default);
+            Assert.That(sut.pointerId, Is.EqualTo(-1));
+            sut.Dispose();
+        }
+
+        [Test]
+        public void Constructor_WithMouse_SetPointerIdIsLeftButton()
+        {
+            var sut = new SimulatedPointerEventData(null, default,
+                SimulatedPointerEventData.PointingDeviceType.Mouse);
+            Assert.That(sut.pointerId, Is.EqualTo(-1));
+            sut.Dispose();
+        }
+
+        [Test]
+        public void Constructor_WithTouchScreen_IncrementTouchCount()
+        {
+            var firstTouch = new SimulatedPointerEventData(null, default,
+                SimulatedPointerEventData.PointingDeviceType.TouchScreen);
+            Assume.That(firstTouch.pointerId, Is.EqualTo(0));
+
+            var secondTouch = new SimulatedPointerEventData(null, default,
+                SimulatedPointerEventData.PointingDeviceType.TouchScreen);
+            Assert.That(secondTouch.pointerId, Is.EqualTo(1));
+
+            firstTouch.Dispose();
+            secondTouch.Dispose();
+        }
+
+        [Test]
+        public void Dispose_WithTouchScreen_DecrementTouchCount()
+        {
+            var firstTouch = new SimulatedPointerEventData(null, default,
+                SimulatedPointerEventData.PointingDeviceType.TouchScreen);
+            Assume.That(firstTouch.pointerId, Is.EqualTo(0));
+            firstTouch.Dispose();
+
+            var secondTouch = new SimulatedPointerEventData(null, default,
+                SimulatedPointerEventData.PointingDeviceType.TouchScreen);
+            Assert.That(secondTouch.pointerId, Is.EqualTo(0));
+            secondTouch.Dispose();
+        }
+    }
+}

--- a/Tests/Runtime/Operators/Utils/SimulatedPointerEventDataTest.cs.meta
+++ b/Tests/Runtime/Operators/Utils/SimulatedPointerEventDataTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cde27eae64654b1796809d21229b9d0f
+timeCreated: 1740895994

--- a/Tests/Runtime/TestDoubles/StubDestroyingItselfWhenPointerDown.cs
+++ b/Tests/Runtime/TestDoubles/StubDestroyingItselfWhenPointerDown.cs
@@ -16,8 +16,8 @@ namespace TestHelper.Monkey.TestDoubles
         {
             var nameToKeepAfterGetDestroy = this.name;
             Debug.Log($"{nameToKeepAfterGetDestroy}.{nameof(OnPointerDown)}");
-            DestroyImmediate(this.gameObject);
-            Debug.Log($"{nameToKeepAfterGetDestroy}.{nameof(DestroyImmediate)}");
+            Destroy(this.gameObject);
+            Debug.Log($"{nameToKeepAfterGetDestroy}.{nameof(Destroy)}");
         }
 
         public void OnPointerUp(PointerEventData eventData)


### PR DESCRIPTION
### Changes

- Fix to reproduce the sequence of events that happen when pointer-clicking
- Change the Operator's operate target from `Component` to `GameObject`
