### PR TITLE
Fix to Hide from "Add Component" picker

### DIFF
--- a/Tests/Runtime/Meshes/OutOfPlaceMesh.cs
+++ b/Tests/Runtime/Meshes/OutOfPlaceMesh.cs
@@ -12,7 +12,7 @@ namespace TestHelper.Monkey.Meshes
     /// </summary>
     [RequireComponent(typeof(MeshCollider))]
     [RequireComponent(typeof(MeshFilter))]
-    [AddComponentMenu("")] // Hide from "Add Component" picker
+    [AddComponentMenu("/")] // Hide from "Add Component" picker
     public class OutOfPlaceMesh : MonoBehaviour
     {
         private static readonly Vector3[] s_vertices =

--- a/Tests/Runtime/TestDoubles/SpyButtonClickReceiver.cs
+++ b/Tests/Runtime/TestDoubles/SpyButtonClickReceiver.cs
@@ -10,7 +10,7 @@ namespace TestHelper.Monkey.TestDoubles
     /// <summary>
     /// OnClick event receiver for UnityEngine.UI.Button
     /// </summary>
-    [AddComponentMenu("")] // Hide from "Add Component" picker
+    [AddComponentMenu("/")] // Hide from "Add Component" picker
     [RequireComponent(typeof(Button))]
     internal class SpyButtonClickReceiver : MonoBehaviour
     {

--- a/Tests/Runtime/TestDoubles/SpyInputFieldValidator.cs
+++ b/Tests/Runtime/TestDoubles/SpyInputFieldValidator.cs
@@ -7,7 +7,7 @@ using UnityEngine.UI;
 
 namespace TestHelper.Monkey.TestDoubles
 {
-    [AddComponentMenu("")] // Hide from "Add Component" picker
+    [AddComponentMenu("/")] // Hide from "Add Component" picker
     [RequireComponent(typeof(InputField))]
     public class SpyInputFieldValidator : MonoBehaviour
     {

--- a/Tests/Runtime/TestDoubles/SpyOnPointerClickHandler.cs
+++ b/Tests/Runtime/TestDoubles/SpyOnPointerClickHandler.cs
@@ -10,7 +10,7 @@ namespace TestHelper.Monkey.TestDoubles
     /// <summary>
     /// Pointer click event handler
     /// </summary>
-    [AddComponentMenu("")] // Hide from "Add Component" picker
+    [AddComponentMenu("/")] // Hide from "Add Component" picker
     internal class SpyOnPointerClickHandler : MonoBehaviour, IPointerClickHandler
     {
         private void Log([CallerMemberName] string member = "")

--- a/Tests/Runtime/TestDoubles/SpyOnPointerDownUpHandler.cs
+++ b/Tests/Runtime/TestDoubles/SpyOnPointerDownUpHandler.cs
@@ -10,7 +10,7 @@ namespace TestHelper.Monkey.TestDoubles
     /// <summary>
     /// Pointer down/up event handler
     /// </summary>
-    [AddComponentMenu("")] // Hide from "Add Component" picker
+    [AddComponentMenu("/")] // Hide from "Add Component" picker
     internal class SpyOnPointerDownUpHandler : MonoBehaviour, IPointerDownHandler, IPointerUpHandler
     {
         private void Log([CallerMemberName] string member = "")

--- a/Tests/Runtime/TestDoubles/SpyPointerClickEventReceiver.cs
+++ b/Tests/Runtime/TestDoubles/SpyPointerClickEventReceiver.cs
@@ -11,7 +11,7 @@ namespace TestHelper.Monkey.TestDoubles
     /// <summary>
     /// Pointer click event receiver using EventTrigger
     /// </summary>
-    [AddComponentMenu("")] // Hide from "Add Component" picker
+    [AddComponentMenu("/")] // Hide from "Add Component" picker
     [RequireComponent(typeof(EventTrigger))]
     internal class SpyPointerClickEventReceiver : MonoBehaviour
     {

--- a/Tests/Runtime/TestDoubles/SpyPointerDownUpEventReceiver.cs
+++ b/Tests/Runtime/TestDoubles/SpyPointerDownUpEventReceiver.cs
@@ -11,7 +11,7 @@ namespace TestHelper.Monkey.TestDoubles
     /// <summary>
     /// Pointer down/up event receiver using EventTrigger
     /// </summary>
-    [AddComponentMenu("")] // Hide from "Add Component" picker
+    [AddComponentMenu("/")] // Hide from "Add Component" picker
     [RequireComponent(typeof(EventTrigger))]
     internal class SpyPointerDownUpEventReceiver : MonoBehaviour
     {

--- a/Tests/Runtime/TestDoubles/StubDestroyingItselfWhenPointerDown.cs
+++ b/Tests/Runtime/TestDoubles/StubDestroyingItselfWhenPointerDown.cs
@@ -9,7 +9,7 @@ namespace TestHelper.Monkey.TestDoubles
     /// <summary>
     /// Pointer down event handler
     /// </summary>
-    [AddComponentMenu("")] // Hide from "Add Component" picker
+    [AddComponentMenu("/")] // Hide from "Add Component" picker
     public class StubDestroyingItselfWhenPointerDown : MonoBehaviour, IPointerDownHandler, IPointerUpHandler
     {
         public void OnPointerDown(PointerEventData eventData)

--- a/Tests/Runtime/TestDoubles/StubLogErrorWhenOnPointerUp.cs
+++ b/Tests/Runtime/TestDoubles/StubLogErrorWhenOnPointerUp.cs
@@ -9,7 +9,7 @@ namespace TestHelper.Monkey.TestDoubles
     /// <summary>
     /// Write LogError when OnPointerUp is called.
     /// </summary>
-    [AddComponentMenu("")] // Hide from "Add Component" picker
+    [AddComponentMenu("/")] // Hide from "Add Component" picker
     public class StubLogErrorWhenOnPointerUp : MonoBehaviour, IPointerDownHandler, IPointerUpHandler
     {
         public void OnPointerDown(PointerEventData eventData)


### PR DESCRIPTION
Due to a regression in Unity (not sure when this started), specifying "" for name no longer hides, so I changed it to "/".

Bug reported: IN-96428

see: https://docs.unity3d.com/ScriptReference/AddComponentMenu-ctor.html
