### PR TITLE
Fix verbose log formatting to use square brackets for lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,12 +412,12 @@ You can output details logs when the `MonkeyConfig.Verbose` is true.
 ##### Lottery entries
 
 ```
-Lottery entries: {
+Lottery entries: [
   StartButton(30502):Button:UGUIClickOperator,
   StartButton(30502):Button:UGUIClickAndHoldOperator,
   MenuButton(30668):Button:UGUIClickOperator,
   MenuButton(30668):Button:UGUIClickAndHoldOperator
-}
+]
 ```
 
 Each entry format is `GameObject` name (instance ID) : `Component` type : `Operator` type.
@@ -451,7 +451,7 @@ Not reachable to CloseButton(-2278), position=(515,-32). Raycast is not hit.
 Or
 
 ```
-Not reachable to BehindButton(-2324), position=(320,240). Raycast hit other objects: {BlockScreen, FrontButton}
+Not reachable to BehindButton(-2324), position=(320,240). Raycast hit other objects: [BlockScreen, FrontButton]
 ```
 
 The former output is when the object is off-screen, and the latter is when other objects hide the pivot position.

--- a/Runtime/DefaultStrategies/DefaultReachableStrategy.cs
+++ b/Runtime/DefaultStrategies/DefaultReachableStrategy.cs
@@ -76,7 +76,7 @@ namespace TestHelper.Monkey.DefaultStrategies
             if (!isSameOrChildObject && verboseLogger != null)
             {
                 var message = new StringBuilder(CreateMessage(gameObject, pointerEventData.position));
-                message.Append(" Raycast hit other objects: {");
+                message.Append(" Raycast hit other objects: [");
                 foreach (var result in _results)
                 {
                     message.Append($"{result.gameObject.name}({result.gameObject.GetInstanceID()})");
@@ -84,7 +84,7 @@ namespace TestHelper.Monkey.DefaultStrategies
                 }
 
                 message.Remove(message.Length - 2, 2);
-                message.Append("}");
+                message.Append("]");
                 verboseLogger.Log(message.ToString());
             }
 

--- a/Runtime/Monkey.cs
+++ b/Runtime/Monkey.cs
@@ -183,9 +183,9 @@ namespace TestHelper.Monkey
                 yield break;
             }
 
-            lotteryEntries.Insert(0, "Lottery entries: {");
+            lotteryEntries.Insert(0, "Lottery entries: [");
             lotteryEntries.Remove(lotteryEntries.Length - 2, 2);
-            lotteryEntries.Append("}");
+            lotteryEntries.Append("]");
             verboseLogger.Log(lotteryEntries.ToString());
         }
 

--- a/Tests/Runtime/DefaultStrategies/DefaultReachableStrategyTest.cs
+++ b/Tests/Runtime/DefaultStrategies/DefaultReachableStrategyTest.cs
@@ -163,7 +163,7 @@ namespace TestHelper.Monkey.DefaultStrategies
 
                 Assert.That(spyLogger.Messages, Has.Count.EqualTo(1));
                 Assert.That(spyLogger.Messages[0], Does.Match(
-                    @"Not reachable to BehindTheWall\(\d+\), position=\(\d+,\d+\)\. Raycast hit other objects: {Wall\(\d+\), BehindTheWall\(\d+\)}"));
+                    @"Not reachable to BehindTheWall\(\d+\), position=\(\d+,\d+\)\. Raycast hit other objects: \[Wall\(\d+\), BehindTheWall\(\d+\)\]"));
                 // Note: No camera when ScreenSpaceOverlay canvas.
             }
 


### PR DESCRIPTION
Before:
```
{1, 2, 3}
```

After:
```
[1, 2, 3]
```
