### PR TITLE
Turn on keep existing initializer arrangements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -258,6 +258,9 @@ dotnet_diagnostic.IDE0060.severity = warning
 # ReSharper comment alignment
 resharper_csharp_int_align_comments = true
 
+# Keep existing initializer arrangements
+resharper_csharp_keep_existing_initializer_arrangement = true
+
 # Some values of the enum are not processed inside 'switch' statement and are handled via default section
 resharper_switch_statement_handles_some_known_enum_values_with_default_highlighting = warning
 


### PR DESCRIPTION
## Summary
- Add `resharper_csharp_keep_existing_initializer_arrangement = true` to .editorconfig
- This setting preserves existing object initializer formatting styles when using ReSharper

## Test plan
- [ ] Verify the EditorConfig setting is properly applied
- [ ] Confirm existing initializer arrangements are preserved during code formatting

🤖 Generated with [Claude Code](https://claude.ai/code)