### PR TITLE
Add finding GameObject in scrollable component to GameObjectFinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,51 @@ public class MyIntegrationTest
 ```
 
 
+#### Find GameObject in scrollable component
+
+Find `GameObject` in scrollable components (e.g., `ScrollRect`) by using paginator functionality.
+A paginator provides step-by-step navigation through scrollable content, making it possible to find objects that are not currently visible in the viewport.
+
+Arguments:
+
+- **matcher**: Custom `IGameObjectMatcher` implementation
+- **reachable**: Find only reachable object. Default is true
+- **interactable**: Find only interactable object. Default is false
+- **paginator**: `IPaginator` implementation for controlling scrollable components
+
+Built-in paginators:
+
+- `UguiScrollRectPaginator`: For `ScrollRect`
+- `UguiScrollbarPaginator`: For `Scrollbar`
+
+Usage:
+
+```csharp
+using NUnit.Framework;
+using TestHelper.Monkey;
+using TestHelper.Monkey.GameObjectMatchers;
+using TestHelper.Monkey.Paginators;
+
+[TestFixture]
+public class MyIntegrationTest
+{
+    [Test]
+    public async Task FindButtonInScrollView()
+    {
+        var finder = new GameObjectFinder();
+        var matcher = new NameMatcher("Button_10");
+
+        var scrollView = GameObject.Find("Scroll View");
+        var scrollRect = scrollView.GetComponent<ScrollRect>();
+        var paginator = new UguiScrollRectPaginator(scrollRect);
+
+        var result = await finder.FindByMatcherAsync(matcher, paginator: paginator);
+        var button = result.GameObject;
+    }
+}
+```
+
+
 #### Operate GameObject
 
 `SelectOperators` and `SelectOperators<T>` are extensions of `GameObject` that return available operators.


### PR DESCRIPTION
### New Feature

#### Find GameObject in scrollable component

Find `GameObject` in scrollable components (e.g., `ScrollRect`) by using paginator functionality.
A paginator provides step-by-step navigation through scrollable content, making it possible to find objects that are not currently visible in the viewport.

Arguments:

- **matcher**: Custom `IGameObjectMatcher` implementation
- **reachable**: Find only reachable object. Default is true
- **interactable**: Find only interactable object. Default is false
- **paginator**: `IPaginator` implementation for controlling scrollable components

Built-in paginators:

- `UguiScrollRectPaginator`: For `ScrollRect`
- `UguiScrollbarPaginator`: For `Scrollbar`

Usage:

```csharp
using NUnit.Framework;
using TestHelper.Monkey;
using TestHelper.Monkey.GameObjectMatchers;
using TestHelper.Monkey.Paginators;

[TestFixture]
public class MyIntegrationTest
{
    [Test]
    public async Task FindButtonInScrollView()
    {
        var finder = new GameObjectFinder();
        var matcher = new NameMatcher("Button_10");

        var scrollView = GameObject.Find("Scroll View");
        var scrollRect = scrollView.GetComponent<ScrollRect>();
        var paginator = new UguiScrollRectPaginator(scrollRect);

        var result = await finder.FindByMatcherAsync(matcher, paginator: paginator);
        var button = result.GameObject;
    }
}
```