### PR TITLE
Fix MatchPath if name includes parentheses case

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Specify the world position where Monkey operators operate.
 
 ### Find and operate GameObject
 
-`GameObjectFinder` is a class that finds `GameObject` by name, path (can specify [glob](https://en.wikipedia.org/wiki/Glob_(programming)) pattern), or custom matcher.
+`GameObjectFinder` is a class that finds `GameObject` by name, path, or custom matcher.
 
 Constructor arguments:
 
@@ -222,7 +222,7 @@ If the timeout, a `TimeoutException` is thrown.
 
 Arguments:
 
-- **path**: Find `GameObject` hierarchy path separated by `/`. Can specify [glob](https://en.wikipedia.org/wiki/Glob_(programming)) pattern
+- **path**: Find `GameObject` hierarchy path separated by `/`. Can specify wildcards of [glob](https://en.wikipedia.org/wiki/Glob_(programming)) pattern (`?`, `*`, and `**`).
 - **reachable**: Find only reachable object. Default is true
 - **interactable**: Find only interactable object. Default is false
 

--- a/Runtime/Extensions/TransformExtensions.cs
+++ b/Runtime/Extensions/TransformExtensions.cs
@@ -59,6 +59,12 @@ namespace TestHelper.Monkey.Extensions
                     case '\\':
                         regex.Append("\\\\");
                         break;
+                    case '(':
+                        regex.Append("\\(");
+                        break;
+                    case ')':
+                        regex.Append("\\)");
+                        break;
                     default:
                         regex.Append(c);
                         break;

--- a/Runtime/GameObjectFinder.cs
+++ b/Runtime/GameObjectFinder.cs
@@ -266,7 +266,7 @@ namespace TestHelper.Monkey
         /// <summary>
         /// Find <c>GameObject</c> by path (wait until they appear).
         /// </summary>
-        /// <param name="path">Find <c>GameObject</c> hierarchy path separated by `/`. Can specify glob pattern</param>
+        /// <param name="path">Find <c>GameObject</c> hierarchy path separated by `/`. Can specify wildcards of glob pattern (`?`, `*`, and `**`).</param>
         /// <param name="reachable">Find only reachable object</param>
         /// <param name="interactable">Find only interactable object</param>
         /// <param name="paginator">Pagination controller for finding <c>GameObject</c> on pageable (or scrollable) UI components (e.g., Scroll view, Carousel, Paged dialog).</param>

--- a/Runtime/GameObjectMatchers/ButtonMatcher.cs
+++ b/Runtime/GameObjectMatchers/ButtonMatcher.cs
@@ -32,7 +32,7 @@ namespace TestHelper.Monkey.GameObjectMatchers
         /// </summary>
         /// <param name="componentType"><c>Button</c> component type. If omitted, <see cref="Button"/> is used.</param>
         /// <param name="name"><see cref="GameObject"/> name</param>
-        /// <param name="path"><see cref="GameObject"/> hierarchy path separated by `/`. Can specify glob pattern</param>
+        /// <param name="path"><see cref="GameObject"/> hierarchy path separated by `/`. Can specify wildcards of glob pattern (`?`, `*`, and `**`).</param>
         /// <param name="text">text under the <c>Button</c></param>
         /// <param name="texture">texture name under the <c>Button</c></param>
         /// <seealso href="https://en.wikipedia.org/wiki/Glob_(programming)"/>

--- a/Runtime/GameObjectMatchers/PathMatcher.cs
+++ b/Runtime/GameObjectMatchers/PathMatcher.cs
@@ -16,7 +16,7 @@ namespace TestHelper.Monkey.GameObjectMatchers
         /// <summary>
         /// Constructor with hierarchy path.
         /// </summary>
-        /// <param name="path"><see cref="GameObject"/> hierarchy path separated by `/`. Can specify glob pattern</param>
+        /// <param name="path"><see cref="GameObject"/> hierarchy path separated by `/`. Can specify wildcards of glob pattern (`?`, `*`, and `**`).</param>
         /// <seealso href="https://en.wikipedia.org/wiki/Glob_(programming)"/>
         public PathMatcher(string path)
         {

--- a/Runtime/GameObjectMatchers/ToggleMatcher.cs
+++ b/Runtime/GameObjectMatchers/ToggleMatcher.cs
@@ -31,7 +31,7 @@ namespace TestHelper.Monkey.GameObjectMatchers
         /// </summary>
         /// <param name="componentType"><c>Toggle</c> component type. If omitted, <see cref="Toggle"/> is used.</param>
         /// <param name="name"><see cref="GameObject"/> name</param>
-        /// <param name="path"><see cref="GameObject"/> hierarchy path separated by `/`. Can specify glob pattern</param>
+        /// <param name="path"><see cref="GameObject"/> hierarchy path separated by `/`. Can specify wildcards of glob pattern (`?`, `*`, and `**`).</param>
         /// <param name="text">text under the <c>Toggle</c></param>
         /// <seealso href="https://en.wikipedia.org/wiki/Glob_(programming)"/>
         public ToggleMatcher(Type componentType = null, string name = null, string path = null, string text = null)

--- a/Tests/Runtime/Extensions/TransformExtensionsTest.cs
+++ b/Tests/Runtime/Extensions/TransformExtensionsTest.cs
@@ -63,5 +63,17 @@ namespace TestHelper.Monkey.Extensions
             var actual = grandchild.transform.MatchPath(glob);
             Assert.That(actual, Is.False);
         }
+
+        [TestCase("/Parent/Child/Grandchild (1)")]
+        [TestCase("/Parent/Child/Grandchild (?)")]
+        [TestCase("/Parent/Child/Grandchild*")]
+        public void MatchPath_WithParenthesis_Match(string glob)
+        {
+            var grandchild = CreateThreeGenerationObjects();
+            grandchild.name = $"{grandchild.name} (1)"; // Set name to include parenthesis
+
+            var actual = grandchild.transform.MatchPath(glob);
+            Assert.That(actual, Is.True);
+        }
     }
 }


### PR DESCRIPTION
### Fixes

- Fix MatchPath if name includes parentheses case
- Fix to clarify that only wildcards are supported among glob patterns
